### PR TITLE
pixi_rare_sort_fastapi: 强制覆盖 pathogenic_rank/evidence_summary（无 _1 后缀）

### DIFF
--- a/pixi_rare_sort_fastapi/.gitattributes
+++ b/pixi_rare_sort_fastapi/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/pixi_rare_sort_fastapi/.gitignore
+++ b/pixi_rare_sort_fastapi/.gitignore
@@ -1,0 +1,3 @@
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/pixi_rare_sort_fastapi/README.md
+++ b/pixi_rare_sort_fastapi/README.md
@@ -1,0 +1,251 @@
+# rare_sort FastAPI
+
+罕见病变异排序评分服务。对 VEP 宽表（CSV/Parquet）进行突变级评分，可选叠加基因表型加权（gene_score）和 PPI 网络加权（ppi_score），输出含 `evolve_score`、`pathogenic_score`、`pathogenic_rank` 的结果 CSV。
+
+零外部私有依赖，所有评分逻辑收敛在 `_core.py`，环境由 Pixi + conda-forge 管理。
+
+## 目录
+
+- [环境要求](#环境要求)
+- [安装与快速开始](#安装与快速开始)
+- [获取输入文件](#获取输入文件)
+- [API 文档](#api-文档)
+- [评分公式](#评分公式)
+- [项目结构](#项目结构)
+
+---
+
+## 环境要求
+
+| 依赖 | 说明 |
+|------|------|
+| Pixi | 包管理与环境隔离。安装：`curl -fsSL https://pixi.prefix.dev/install.sh \| bash` |
+
+Python、FastAPI、duckdb、pandas 等全部由 Pixi 自动安装，无需手动管理。
+
+## 安装与快速开始
+
+```bash
+# 1. 获取代码
+git clone git@github.com:OpenRare2026/OpenRare.git
+cd OpenRare && git checkout dev-wyz
+cd pixi_rare_sort_fastapi
+
+# 2. 添加平台支持（按需）
+pixi workspace platform add osx-arm64   # macOS Apple Silicon
+pixi workspace platform add linux-64    # Linux x86_64
+
+# 3. 安装依赖
+pixi install
+
+# 4. 启动服务（默认 5000 端口）
+pixi run start
+
+# 5. 验证
+curl http://localhost:5000/jobs
+# → {}
+```
+
+服务器上 Pixi 路径为 `/mnt/workspace/hujie/pixi`，用此路径替换上述 `pixi` 命令。
+
+## 获取输入文件
+
+服务需要三类文件，均来自 OpenRare 管线上游：
+
+### VEP 宽表（必填）
+
+`complete_pipeline` → `06_result_sorting/vep_output.sorted.csv`
+
+必须含以下列：`chrom`, `pos`, `ref`, `alt`, `gene_symbol`, `tx_rank_within_variant`，以及评分所需的 ClinVar、consequence、spliceAI、REVEL/CADD、gnomAD、protein_domains 列。
+
+### gene_phenotype_score.csv（可选）
+
+HPO 表型匹配服务输出，含 `gene_symbol` 和 `gene_score` 列。
+
+```
+gene_symbol,gene_score,...
+MTM1,0.673790,...
+PDHA1,0.656325,...
+```
+
+### ppi_score.csv（可选）
+
+PPI 网络分析服务输出，含 `gene` 和 `ppi_final` 列。
+
+```
+gene,ppi_final,...
+CDC42,0.999599,...
+RPL5,0.999153,...
+```
+
+---
+
+## API 文档
+
+### 端点一览
+
+| 接口 | 方法 | 描述 |
+|------|------|------|
+| `/score` | POST | 服务器已有文件评分 |
+| `/score/upload` | POST | 上传文件评分 |
+| `/status/{job_id}` | GET | 查询任务状态 |
+| `/output/{job_id}` | GET | 下载结果 CSV |
+| `/jobs` | GET | 列出全部任务 |
+
+### 任务状态
+
+| status | 含义 |
+|--------|------|
+| `queued` | 已入队 |
+| `running` | 执行中，含 `started_at` |
+| `done` | 完成，含 `output` 路径和 `elapsed` 秒数 |
+| `failed` | 失败，含 `error` |
+
+### POST /score
+
+| 参数 | 类型 | 必填 | 描述 |
+|------|------|------|------|
+| `input_path` | string | 是 | 服务器上 VEP 文件绝对路径 |
+| `gene_score_path` | string | 否 | gene_phenotype_score.csv 路径 |
+| `ppi_score_path` | string | 否 | ppi_score.csv 路径 |
+
+```bash
+# 仅突变级评分
+curl -X POST "http://localhost:5000/score?input_path=/data/vep.csv"
+
+# 完整三文件评分
+curl -X POST "http://localhost:5000/score?input_path=/data/vep.csv&gene_score_path=/data/gene_phenotype_score.csv&ppi_score_path=/data/ppi_score.csv"
+# → {"job_id":"a1b2c3d4","status":"queued"}
+```
+
+### POST /score/upload
+
+| 参数 | 类型 | 必填 | 描述 |
+|------|------|------|------|
+| `file` | file | 是 | VEP CSV/Parquet |
+| `gene_score_file` | file | 否 | gene_phenotype_score.csv |
+| `ppi_score_file` | file | 否 | ppi_score.csv |
+
+```bash
+curl -X POST http://localhost:5000/score/upload \
+  -F "file=@vep_output.csv" \
+  -F "gene_score_file=@gene_phenotype_score.csv" \
+  -F "ppi_score_file=@ppi_score.csv"
+# → {"job_id":"abc12345","status":"queued","filename":"vep_output.csv"}
+```
+
+### GET /status/{job_id}
+
+```bash
+curl http://localhost:5000/status/abc12345
+# → {"status":"done","output":"/home/.../outputs/abc12345.csv","elapsed":2.07}
+```
+
+### GET /output/{job_id}
+
+下载已完成任务的结果 CSV 文件。输出持久化在 `outputs/` 目录，服务重启不丢失。
+
+```bash
+curl -O http://localhost:5000/output/abc12345
+# → 下载 abc12345.csv
+```
+
+### GET /jobs
+
+```bash
+curl http://localhost:5000/jobs
+# → {"abc12345":{"status":"done","input":"/data/vep.csv","filename":null}}
+```
+
+---
+
+## 评分公式
+
+### Pass 1 — 突变级评分（Python）
+
+6 个 Contributor，每个有固定 calibrate 函数（`_core.py`），加权求和：
+
+```
+evolve_score = Σ (theta_i × calibrate_i(row))
+```
+
+theta 权重固定：
+
+| Contributor | theta | 依赖列 |
+|-------------|-------|--------|
+| clinvar_score | 1.291 | clinvar_significance, clinvar_star_rating, clinvar_review_status |
+| consequence_score | 1.101 | consequence, impact |
+| splice_lof_score | 2.027 | spliceAI_ds_max, spliceAI_type, loftee_lof_flag, loftee_lof_filter |
+| prediction_score | 0.497 | revel_score, cadd_phred |
+| frequency_score | 0.210 | gnomAD_eas_AF, gnomAD_popmax_AF, gnomAD_nhomalt |
+| domain_score | 3.661 | protein_domains |
+
+结果按 variant 去重（tx_rank==1 优先），`evolve_rank` 降序编号。
+
+### Pass 2 — 基因加权（duckdb SQL）
+
+gene_score 和 ppi_final 采用 **加分因子**策略（≥ 0.9）：
+
+```
+factor(x) = NULL      → 1.0         （无数据，不增不减）
+            = 0        → 0.9         （确认无证据，轻微打折）
+            > 0        → 1.0 + √(x)  （有证据，加分）
+```
+
+**仅 gene_score：**
+```
+pathogenic_score = evolve_score × factor(gene_score)
+```
+
+**仅 ppi_score：**
+```
+pathogenic_score = evolve_score × factor(ppi_final)
+```
+
+**gene_score + ppi_score：**
+```
+pathogenic_score = evolve_score × factor(gene_score) × factor(ppi_final)
+```
+
+**不加权：** `pathogenic_score = evolve_score`
+
+因子效果示例：
+
+| ppi_final | factor | 效果 |
+|-----------|--------|------|
+| NULL | 1.0 | 不变 |
+| 0 | 0.9 | -10% |
+| 0.2 | 1.447 | +45% |
+| 0.5 | 1.707 | +71% |
+| 0.8 | 1.894 | +89% |
+
+`pathogenic_rank` 按 `pathogenic_score` 降序重排。
+
+### 输出列
+
+始终输出：原始 VEP 列 + `evolve_score` + `evolve_rank` + `pathogenic_score` + `pathogenic_rank`。提供 gene_score 时额外含 `gene_score`，提供 ppi_score 时额外含 `ppi_final`。
+
+---
+
+## 项目结构
+
+```text
+pixi_rare_sort_fastapi/
+├── main.py          # FastAPI 入口，5 端点 + 异步任务队列
+├── pipeline.py       # 评分流水线（Pass 1 特征提取 → Pass 2 duckdb JOIN）
+├── _core.py          # 评分核心（6 个 Contributor calibrate + apply_theta + rank_units）
+├── dataio.py         # 宽表 I/O（列裁剪 + 分块流式，自动选引擎）
+├── outputs/          # 结果输出目录，持久化存储
+├── pixi.toml         # 项目清单（全部依赖 conda-forge）
+├── pixi.lock         # 依赖版本锁定
+└── README.md
+```
+
+| 文件 | 作用 |
+|------|------|
+| `main.py` | FastAPI 服务，内存任务队列，输出持久化，支持下载 |
+| `pipeline.py` | 两阶段流水线，Pass 1 Python 打分 → Pass 2 duckdb JOIN + 基因加权 |
+| `_core.py` | 评分核心：Contributor、calibrate、theta 加权、去重排名 |
+| `dataio.py` | 大规模 I/O，引擎优先级 duckdb > polars > pyarrow > pandas |
+| `pixi.toml` | 依赖声明，全部来自 conda-forge |
+| `pixi.lock` | 锁定版本，跨机器复现 |

--- a/pixi_rare_sort_fastapi/_core.py
+++ b/pixi_rare_sort_fastapi/_core.py
@@ -1,0 +1,318 @@
+"""Standalone scoring core — no rare_sort dependency.
+
+Contains: Contributor registry, calibrate functions, feature extraction, theta
+application, and variant-level ranking. Everything pipeline.py needs, in one file.
+"""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# helpers (formerly rare_sort._util)
+# ---------------------------------------------------------------------------
+_MISSING = {"", "-", "na", "n/a", "none", "."}
+
+
+def is_missing(x) -> bool:
+    if x is None:
+        return True
+    if isinstance(x, float) and math.isnan(x):
+        return True
+    if isinstance(x, str) and x.strip().lower() in _MISSING:
+        return True
+    return False
+
+
+def to_float(x) -> Optional[float]:
+    if is_missing(x):
+        return None
+    try:
+        return float(str(x).strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def to_int(x) -> Optional[int]:
+    f = to_float(x)
+    return None if f is None else int(round(f))
+
+
+def norm_token(x) -> str:
+    if is_missing(x):
+        return ""
+    return re.sub(r"[^a-z0-9]+", "_", str(x).strip().lower()).strip("_")
+
+
+def split_terms(x) -> list[str]:
+    if is_missing(x):
+        return []
+    return [norm_token(t) for t in re.split(r"[&,;]+", str(x)) if norm_token(t)]
+
+
+def variant_key(chrom, pos, ref, alt) -> tuple:
+    c = str(chrom).strip()
+    c = c[3:] if c.lower().startswith("chr") else c
+    return (c, str(pos).strip(), str(ref).strip().upper(), str(alt).strip().upper())
+
+
+# ---------------------------------------------------------------------------
+# contributor framework (formerly rare_sort.contributors)
+# ---------------------------------------------------------------------------
+ADDITIVE = "ADDITIVE"
+GENE_PRIOR = "GENE_PRIOR"
+
+
+@dataclass(frozen=True)
+class Contributor:
+    name: str
+    calibrate: Callable[[dict], float]
+    kind: str = ADDITIVE
+    group: Optional[str] = None
+    weight_key: Optional[str] = None
+    reads: tuple[str, ...] = field(default_factory=tuple)
+
+    def key(self) -> str:
+        return self.weight_key or self.name
+
+
+# 1. clinvar_score
+_SIG_BASE = {
+    "pathogenic": 40, "likely_pathogenic": 30,
+    "pathogenic_likely_pathogenic": 35, "uncertain_significance": 3,
+    "likely_benign": -25, "benign": -35, "benign_likely_benign": -30,
+}
+_BENIGN_ADJUST = {"benign": 0.95, "likely_benign": 0.90, "benign_likely_benign": 0.925}
+_STAR_FACTOR = {4: 1.20, 3: 1.15, 2: 1.10, 1: 1.00, 0: 1.00}
+
+
+def _sig_base(sig_norm: str) -> Optional[int]:
+    if sig_norm in _SIG_BASE:
+        return _SIG_BASE[sig_norm]
+    if "conflicting" in sig_norm:
+        return 0
+    if "uncertain" in sig_norm:
+        return 3
+    return None
+
+
+def _review_factor(review_norm: str) -> float:
+    if "practice_guideline" in review_norm or "expert_panel" in review_norm:
+        return 1.15
+    if "multiple_submitters" in review_norm and "no_conflicts" in review_norm:
+        return 1.10
+    return 1.00
+
+
+def _clinvar(row: dict) -> float:
+    sig = norm_token(row.get("clinvar_significance"))
+    base = _sig_base(sig)
+    if base is None or base == 0:
+        return 0.0
+    star = to_int(row.get("clinvar_star_rating")) or 0
+    star = max(0, min(4, star))
+    star_factor = _STAR_FACTOR[star]
+    review_factor = _review_factor(norm_token(row.get("clinvar_review_status")))
+    benign_adjust = _BENIGN_ADJUST.get(sig, 1.0)
+    return float(round(base * star_factor * review_factor * benign_adjust))
+
+
+# 2. consequence_score
+_CONS_BASE = {
+    "transcript_ablation": 30, "splice_acceptor_variant": 28,
+    "splice_donor_variant": 28, "stop_gained": 28, "frameshift_variant": 28,
+    "stop_lost": 24, "start_lost": 22, "missense_variant": 12,
+    "protein_altering_variant": 12, "inframe_insertion": 10,
+    "inframe_deletion": 10, "splice_region_variant": 6,
+    "synonymous_variant": 2, "intron_variant": 0,
+    "upstream_gene_variant": -3, "downstream_gene_variant": -3,
+    "intergenic_variant": -5,
+}
+_IMPACT_SCORE = {"HIGH": 5, "MODERATE": 3, "LOW": 0, "MODIFIER": -3}
+
+
+def _consequence(row: dict) -> float:
+    terms = split_terms(row.get("consequence"))
+    mapped = [_CONS_BASE[t] for t in terms if t in _CONS_BASE]
+    base = max(mapped) if mapped else 0
+    impact = row.get("impact")
+    impact_score = _IMPACT_SCORE.get(str(impact).strip().upper(), 0) if not is_missing(impact) else 0
+    return float(base + impact_score)
+
+
+# 3. splice_lof_score
+_LOF_CONSEQUENCES = {
+    "transcript_ablation", "splice_acceptor_variant", "splice_donor_variant",
+    "stop_gained", "frameshift_variant", "stop_lost", "start_lost",
+}
+
+
+def _splice_lof(row: dict) -> float:
+    s = 0.0
+    ds = to_float(row.get("spliceAI_ds_max"))
+    if ds is not None:
+        if ds >= 0.8:       s += 20
+        elif ds >= 0.5:     s += 15
+        elif ds >= 0.2:     s += 8
+        elif ds >= 0.1:     s += 3
+        if ds >= 0.2 and not is_missing(row.get("spliceAI_type")):
+            s += 2
+    terms = set(split_terms(row.get("consequence")))
+    if terms & _LOF_CONSEQUENCES:
+        if not is_missing(row.get("loftee_lof_filter")):
+            s += -8
+        flag = norm_token(row.get("loftee_lof_flag")).upper()
+        if flag == "HC":        s += 15
+        elif flag == "LC":      s += 5
+        elif flag:              s += -3
+    return s
+
+
+# 4. prediction_score (REVEL + CADD; only for missense / protein_altering)
+def _prediction(row: dict) -> float:
+    terms = set(split_terms(row.get("consequence")))
+    if not (terms & {"missense_variant", "protein_altering_variant"}):
+        return 0.0
+    s = 0.0
+    revel = to_float(row.get("revel_score"))
+    if revel is not None:
+        if revel >= 0.9:     s += 15
+        elif revel >= 0.75:  s += 12
+        elif revel >= 0.5:   s += 8
+        elif revel >= 0.25:  s += 3
+    cadd = to_float(row.get("cadd_phred"))
+    if cadd is not None:
+        if cadd >= 30:       s += 12
+        elif cadd >= 25:     s += 9
+        elif cadd >= 20:     s += 6
+        elif cadd >= 10:     s += 2
+    return s
+
+
+# 5. frequency_score
+def _frequency(row: dict) -> float:
+    s = 0.0
+    eas = to_float(row.get("gnomAD_eas_AF"))
+    popmax = to_float(row.get("gnomAD_popmax_AF"))
+    nhomalt = to_int(row.get("gnomAD_nhomalt"))
+    if eas is not None:
+        if eas < 0.0001:        s += 10
+        elif eas < 0.001:       s += 8
+        elif eas < 0.01:        s += 3
+        elif eas <= 0.05:       s += -10
+        else:                   s += -25
+        if popmax is not None:
+            if popmax > 0.05:   s += -10
+            elif popmax > 0.01: s += -5
+    elif popmax is not None:
+        if popmax < 0.0001:     s += 8
+        elif popmax < 0.001:    s += 6
+        elif popmax < 0.01:     s += 2
+        elif popmax <= 0.05:    s += -8
+        else:                   s += -20
+    if nhomalt is not None:
+        if 1 <= nhomalt <= 5:   s += -3
+        elif 6 <= nhomalt <= 20: s += -8
+        elif nhomalt > 20:      s += -15
+    if eas is None and popmax is None:
+        s += 5
+    return s
+
+
+# 6. domain_score
+def _domain(row: dict) -> float:
+    return 3.0 if not is_missing(row.get("protein_domains")) else 0.0
+
+
+def default_registry() -> list[Contributor]:
+    return [
+        Contributor("consequence_score", _consequence,
+                    reads=("consequence", "impact")),
+        Contributor("splice_lof_score", _splice_lof,
+                    reads=("spliceAI_ds_max", "spliceAI_type", "consequence",
+                           "loftee_lof_flag", "loftee_lof_filter")),
+        Contributor("prediction_score", _prediction,
+                    reads=("consequence", "revel_score", "cadd_phred")),
+        Contributor("frequency_score", _frequency,
+                    reads=("gnomAD_eas_AF", "gnomAD_popmax_AF", "gnomAD_nhomalt")),
+        Contributor("clinvar_score", _clinvar, group="clinvar",
+                    reads=("clinvar_significance", "clinvar_star_rating",
+                           "clinvar_review_status")),
+        Contributor("domain_score", _domain, reads=("protein_domains",)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# scoring / ranking (formerly rare_sort.scorer)
+# ---------------------------------------------------------------------------
+_IDENTITY = ("chrom", "pos", "ref", "alt")
+_INDEX_EXTRA = ("gene_symbol", "tx_rank_within_variant", "tx_selected_reason")
+
+
+def theta_keys(registry: list[Contributor]) -> list[str]:
+    return [c.key() for c in registry]
+
+
+def needed_columns(registry: list[Contributor]) -> list[str]:
+    cols = list(_IDENTITY) + list(_INDEX_EXTRA)
+    for c in registry:
+        cols.extend(c.reads)
+    seen, out = set(), []
+    for c in cols:
+        if c not in seen:
+            seen.add(c)
+            out.append(c)
+    return out
+
+
+@dataclass
+class FeatureBundle:
+    F: np.ndarray
+    keys: list[str]
+    kinds: list[str]
+    groups: list[Optional[str]]
+    index: pd.DataFrame
+
+
+def apply_theta(bundle: FeatureBundle, theta: dict) -> np.ndarray:
+    """Vectorized: additive columns → F @ theta. (Gate/GENE_PRIOR not used by v1 registry.)"""
+    keys, kinds = bundle.keys, bundle.kinds
+    tvec = np.array([float(theta.get(k, 1.0)) for k in keys], dtype=float)
+    is_add = np.array([k == ADDITIVE for k in kinds])  # all 6 contributors are ADDITIVE
+    add_theta = tvec.copy()
+    add_theta[~is_add] = 0.0
+    return bundle.F @ add_theta
+
+
+def rank_units(bundle: FeatureBundle, scores: np.ndarray, level: str = "variant",
+               collapse: str = "auto") -> pd.DataFrame:
+    """Collapse to variant level, stable-sort desc, add 1-based rank."""
+    idx = bundle.index.copy()
+    idx["score"] = scores
+    if level == "row":
+        idx["_unit"] = idx["_order"]
+        idx["_rep_row"] = idx["_order"]
+    else:
+        have_tx = "tx_rank" in idx.columns and idx["tx_rank"].notna().any()
+        if collapse in ("auto", "selected_transcript") and have_tx:
+            idx = idx.copy()
+            idx["_sel"] = (idx["tx_rank"] == 1).astype(int)
+            idx = idx.sort_values(["_vkey", "_sel", "score"],
+                                  ascending=[True, False, False], kind="mergesort")
+            reps = idx.groupby("_vkey", sort=False).head(1)
+        else:
+            keep = idx.groupby("_vkey", sort=False)["score"].idxmax()
+            reps = idx.loc[keep]
+        reps = reps.copy()
+        reps["_unit"] = reps["_vkey"]
+        reps["_rep_row"] = reps["_order"]
+        idx = reps
+    ranked = idx.sort_values(["score", "_order"], ascending=[False, True],
+                             kind="mergesort").reset_index(drop=True)
+    ranked["rank"] = np.arange(1, len(ranked) + 1)
+    return ranked

--- a/pixi_rare_sort_fastapi/dataio.py
+++ b/pixi_rare_sort_fastapi/dataio.py
@@ -1,0 +1,187 @@
+"""Scalable table I/O -- the ONLY module that touches the full wide table.
+
+At 9 GB the bottleneck is reading, so we never read the whole table:
+  * column projection -- read only needed_columns(registry), not all columns.
+    Parquet is columnar, so unread columns cost nothing; CSV still byte-scans
+    but at least we avoid materializing unused columns.
+  * predicate pushdown -- optionally read only the selected transcript per
+    variant (one row per variant instead of one per variant x transcript).
+  * chunked streaming -- yield bounded row-batches so memory is O(chunk),
+    not O(table). Feature extraction accumulates a tiny (n_rows x 6) matrix.
+
+Engines, in preference order: duckdb (projection+predicate+streaming on both
+parquet and csv), polars (if installed), pyarrow (parquet), pandas (fallback).
+All values are returned as strings with missing == "-", matching the parsing
+convention the contributors expect.
+"""
+from __future__ import annotations
+
+import os
+from typing import Iterable, Iterator, Optional
+
+import pandas as pd
+
+# selected-transcript predicate (null-safe: keep variants lacking a ranked tx)
+SELECTED_TX_SQL = ("(CAST(tx_rank_within_variant AS VARCHAR) = '1' "
+                   "OR tx_rank_within_variant IS NULL)")
+
+
+def available_engines() -> list[str]:
+    out = []
+    for m in ("duckdb", "polars", "pyarrow"):
+        try:
+            __import__(m)
+            out.append(m)
+        except Exception:
+            pass
+    out.append("pandas")
+    return out
+
+
+def _detect_fmt(path: str, fmt: str) -> str:
+    if fmt != "auto":
+        return fmt
+    low = path.lower()
+    if low.endswith((".parquet", ".pq")):
+        return "parquet"
+    if low.endswith((".csv", ".csv.gz", ".tsv", ".txt", ".gz")):
+        return "csv"
+    return "parquet"
+
+
+def _pick_engine(engine: str) -> str:
+    if engine != "auto":
+        return engine
+    eng = available_engines()
+    return eng[0]
+
+
+def _normalize(df: pd.DataFrame, want: list[str]) -> pd.DataFrame:
+    """Project to exactly `want` (adding any missing column as '-'), in order,
+    with all values as strings and missing == '-'."""
+    for c in want:
+        if c not in df.columns:
+            df[c] = "-"
+    df = df.loc[:, list(want)]
+    df = df.where(pd.notna(df), "-")
+    df = df.astype(str)
+    return df.replace({"None": "-", "nan": "-", "NaN": "-", "<NA>": "-", "": "-"})
+
+
+# --------------------------------------------------------------------------
+# duckdb (primary): projection + optional predicate + streaming, parquet & csv
+# --------------------------------------------------------------------------
+def _duckdb_source(path: str, fmt: str) -> str:
+    p = path.replace("'", "''")
+    if fmt == "csv":
+        return f"read_csv_auto('{p}', all_varchar=true)"
+    return f"read_parquet('{p}')"
+
+
+def _duckdb_iter(path, want, fmt, row_filter, chunk_rows) -> Iterator[pd.DataFrame]:
+    import duckdb
+    con = duckdb.connect()
+    try:
+        src = _duckdb_source(path, fmt)
+        schema = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM {src}").fetchall()]
+        sel = [c for c in want if c in schema]
+        proj = ", ".join(f'CAST("{c}" AS VARCHAR) AS "{c}"' for c in sel) or "NULL"
+        q = f"SELECT {proj} FROM {src}"
+        if row_filter and "tx_rank_within_variant" in schema:
+            q += f" WHERE {row_filter}"
+        reader = con.execute(q).fetch_record_batch(chunk_rows)
+        for batch in reader:
+            yield _normalize(batch.to_pandas(), want)
+    finally:
+        con.close()
+
+
+# --------------------------------------------------------------------------
+# polars (optional): lazy scan + projection
+# --------------------------------------------------------------------------
+def _polars_iter(path, want, fmt, row_filter, chunk_rows) -> Iterator[pd.DataFrame]:
+    import polars as pl
+    lf = pl.scan_parquet(path) if fmt == "parquet" else pl.scan_csv(path, infer_schema_length=0)
+    have = lf.collect_schema().names()
+    sel = [c for c in want if c in have]
+    lf = lf.select(sel)
+    if row_filter == "selected_tx" and "tx_rank_within_variant" in have:
+        lf = lf.filter((pl.col("tx_rank_within_variant").cast(pl.Utf8) == "1")
+                       | pl.col("tx_rank_within_variant").is_null())
+    df = lf.collect().to_pandas()
+    for i in range(0, len(df), chunk_rows):
+        yield _normalize(df.iloc[i:i + chunk_rows].copy(), want)
+
+
+# --------------------------------------------------------------------------
+# pyarrow (parquet) / pandas (csv) fallback
+# --------------------------------------------------------------------------
+def _pyarrow_iter(path, want, row_filter, chunk_rows) -> Iterator[pd.DataFrame]:
+    import pyarrow.dataset as ds
+    d = ds.dataset(path, format="parquet")
+    sel = [c for c in want if c in d.schema.names]
+    for batch in d.scanner(columns=sel, batch_size=chunk_rows).to_batches():
+        df = _normalize(batch.to_pandas(), want)
+        if row_filter == "selected_tx" and "tx_rank_within_variant" in df.columns:
+            df = df[(df["tx_rank_within_variant"] == "1")
+                    | (df["tx_rank_within_variant"] == "-")]
+        if len(df):
+            yield df
+
+
+def _pandas_csv_iter(path, want, row_filter, chunk_rows) -> Iterator[pd.DataFrame]:
+    head = pd.read_csv(path, nrows=0)
+    sel = [c for c in want if c in head.columns]
+    for chunk in pd.read_csv(path, dtype=str, keep_default_na=False,
+                             usecols=sel or None, chunksize=chunk_rows):
+        df = _normalize(chunk, want)
+        if row_filter == "selected_tx" and "tx_rank_within_variant" in df.columns:
+            df = df[(df["tx_rank_within_variant"] == "1")
+                    | (df["tx_rank_within_variant"] == "-")]
+        if len(df):
+            yield df
+
+
+# --------------------------------------------------------------------------
+# public API
+# --------------------------------------------------------------------------
+def iter_chunks(path: str, columns: Iterable[str], *, engine: str = "auto",
+                fmt: str = "auto", row_filter: Optional[str] = None,
+                chunk_rows: int = 250_000, selected_tx_only: bool = False
+                ) -> Iterator[pd.DataFrame]:
+    """Yield projected, string-normalized row-batches for one case file.
+
+    row_filter: raw SQL (duckdb only) OR the sentinel 'selected_tx'. The
+    convenience flag selected_tx_only=True sets the null-safe selected-transcript
+    predicate for every engine."""
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    want = list(dict.fromkeys(columns))
+    fmt = _detect_fmt(path, fmt)
+    eng = _pick_engine(engine)
+    if selected_tx_only and not row_filter:
+        row_filter = SELECTED_TX_SQL if eng == "duckdb" else "selected_tx"
+
+    if eng == "duckdb":
+        yield from _duckdb_iter(path, want, fmt, row_filter, chunk_rows)
+    elif eng == "polars":
+        yield from _polars_iter(path, want, fmt,
+                                "selected_tx" if selected_tx_only else None, chunk_rows)
+    elif eng == "pyarrow" and fmt == "parquet":
+        yield from _pyarrow_iter(path, want,
+                                 "selected_tx" if selected_tx_only else None, chunk_rows)
+    else:
+        yield from _pandas_csv_iter(path, want,
+                                    "selected_tx" if selected_tx_only else None, chunk_rows)
+
+
+def read_columns(path: str, columns: Iterable[str], *, engine: str = "auto",
+                 fmt: str = "auto", row_filter: Optional[str] = None,
+                 selected_tx_only: bool = False) -> pd.DataFrame:
+    """Read one case file fully into memory, projected to `columns` only."""
+    parts = list(iter_chunks(path, columns, engine=engine, fmt=fmt,
+                             row_filter=row_filter, chunk_rows=250_000,
+                             selected_tx_only=selected_tx_only))
+    if not parts:
+        return _normalize(pd.DataFrame(), list(dict.fromkeys(columns)))
+    return pd.concat(parts, ignore_index=True)

--- a/pixi_rare_sort_fastapi/main.py
+++ b/pixi_rare_sort_fastapi/main.py
@@ -1,0 +1,118 @@
+"""ponytail: FastAPI wrapper — file upload + async job queue (in-memory dict)."""
+from __future__ import annotations
+
+import os, uuid, threading, time
+from pathlib import Path
+
+from fastapi import FastAPI, Query, UploadFile, File, HTTPException
+from fastapi.responses import FileResponse
+import uvicorn
+
+from pipeline import run
+
+app = FastAPI(title="rare_sort")
+
+OUTPUT_DIR = Path(__file__).resolve().parent / "outputs"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+# ponytail: in-memory dict, lost on restart. Output files persist on disk.
+jobs: dict[str, dict] = {}
+
+
+def _run_job(job_id: str, input_path: str, gene_score_csv: str | None = None,
+             ppi_score_csv: str | None = None):
+    jobs[job_id]["status"] = "running"
+    jobs[job_id]["started_at"] = time.time()
+    try:
+        output = str(OUTPUT_DIR / f"{job_id}.csv")
+        result_path = run(input_path, output,
+                          gene_score_csv=gene_score_csv,
+                          ppi_score_csv=ppi_score_csv)
+        jobs[job_id]["status"] = "done"
+        jobs[job_id]["output"] = result_path
+        jobs[job_id]["elapsed"] = time.time() - jobs[job_id]["started_at"]
+    except Exception as e:
+        jobs[job_id]["status"] = "failed"
+        jobs[job_id]["error"] = str(e)
+
+
+@app.post("/score")
+def score_path(input_path: str = Query(..., description="CSV/Parquet path on server"),
+               gene_score_path: str | None = Query(None, description="gene_phenotype_score.csv path (optional)"),
+               ppi_score_path: str | None = Query(None, description="ppi_score.csv path (optional)")):
+    if not os.path.exists(input_path):
+        raise HTTPException(404, f"input not found: {input_path}")
+    if gene_score_path and not os.path.exists(gene_score_path):
+        raise HTTPException(404, f"gene_score file not found: {gene_score_path}")
+    if ppi_score_path and not os.path.exists(ppi_score_path):
+        raise HTTPException(404, f"ppi_score file not found: {ppi_score_path}")
+    job_id = uuid.uuid4().hex[:8]
+    jobs[job_id] = {"status": "queued", "input": input_path, "created_at": time.time(),
+                    "gene_score_path": gene_score_path, "ppi_score_path": ppi_score_path}
+    threading.Thread(target=_run_job, args=(job_id, input_path, gene_score_path, ppi_score_path), daemon=True).start()
+    return {"job_id": job_id, "status": "queued"}
+
+
+@app.post("/score/upload")
+async def score_upload(file: UploadFile = File(...),
+                       gene_score_file: UploadFile | None = None,
+                       ppi_score_file: UploadFile | None = None):
+    import tempfile
+    tmpdir = tempfile.mkdtemp()
+    input_path = os.path.join(tmpdir, file.filename or "upload.csv")
+    with open(input_path, "wb") as f:
+        while chunk := await file.read(8 * 1024 * 1024):
+            f.write(chunk)
+
+    gene_score_path = None
+    if gene_score_file:
+        gene_score_path = os.path.join(tmpdir, gene_score_file.filename or "gene_score.csv")
+        with open(gene_score_path, "wb") as f:
+            while chunk := await gene_score_file.read(8 * 1024 * 1024):
+                f.write(chunk)
+
+    ppi_score_path = None
+    if ppi_score_file:
+        ppi_score_path = os.path.join(tmpdir, ppi_score_file.filename or "ppi_score.csv")
+        with open(ppi_score_path, "wb") as f:
+            while chunk := await ppi_score_file.read(8 * 1024 * 1024):
+                f.write(chunk)
+
+    job_id = uuid.uuid4().hex[:8]
+    jobs[job_id] = {"status": "queued", "input": input_path, "filename": file.filename, "created_at": time.time()}
+    if gene_score_path:
+        jobs[job_id]["gene_score_path"] = gene_score_path
+    if ppi_score_path:
+        jobs[job_id]["ppi_score_path"] = ppi_score_path
+    threading.Thread(target=_run_job, args=(job_id, input_path, gene_score_path, ppi_score_path), daemon=True).start()
+    return {"job_id": job_id, "status": "queued", "filename": file.filename}
+
+
+@app.get("/status/{job_id}")
+def job_status(job_id: str):
+    j = jobs.get(job_id)
+    if not j:
+        raise HTTPException(404, f"job not found: {job_id}")
+    return j
+
+
+@app.get("/output/{job_id}")
+def download_output(job_id: str):
+    j = jobs.get(job_id)
+    if not j:
+        raise HTTPException(404, f"job not found: {job_id}")
+    if j["status"] != "done":
+        raise HTTPException(404, f"job not done (status: {j['status']})")
+    path = j.get("output")
+    if not path or not os.path.exists(path):
+        raise HTTPException(404, "output file not found on disk")
+    return FileResponse(path, filename=f"{job_id}.csv", media_type="text/csv")
+
+
+@app.get("/jobs")
+def list_jobs():
+    return {k: {"status": v["status"], "input": v.get("input"), "filename": v.get("filename")} for k, v in jobs.items()}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=5000)

--- a/pixi_rare_sort_fastapi/pipeline.py
+++ b/pixi_rare_sort_fastapi/pipeline.py
@@ -1,0 +1,264 @@
+"""rare_sort scoring pipeline — CSV/Parquet → ranked CSV.
+
+Usage:
+    python pipeline.py input.csv [--output ranked.csv]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import dataio
+from dataio import available_engines, iter_chunks
+
+from _core import default_registry, needed_columns, theta_keys, FeatureBundle, apply_theta, rank_units, variant_key, to_int
+
+
+# ponytail: tuned theta from P12 v2 (LLMProposer, 2026-06-18)
+P12_V2_THETA = {
+    "clinvar_score": 1.291,
+    "consequence_score": 1.101,
+    "splice_lof_score": 2.027,
+    "prediction_score": 0.497,
+    "frequency_score": 0.210,
+    "domain_score": 3.661,
+}
+
+# evidence_detail maps contributor key → lambda for detail string
+_EV_MAP = [
+    lambda r: f"consequence={r.get('consequence')}(impact={r.get('impact')})",
+    lambda r: f"splice_lof=SpliceAI:{r.get('spliceAI_ds_max')};LoF_flag:{r.get('loftee_lof_flag')}",
+    lambda r: f"prediction=REVEL:{r.get('revel_score')};CADD:{r.get('cadd_phred')}",
+    lambda r: f"frequency=EAS:{r.get('gnomAD_eas_AF')};popmax:{r.get('gnomAD_popmax_AF')};nhomalt:{r.get('gnomAD_nhomalt')}",
+    lambda r: f"clinvar={r.get('clinvar_significance')}(stars={r.get('clinvar_star_rating')})",
+    lambda r: f"domain={'present' if r.get('protein_domains','-') not in ('-','') else 'absent'}",
+]
+
+
+def _evidence_str(row: dict, raw_scores, registry) -> str:
+    parts = []
+    total = 0.0
+    for j, c in enumerate(registry):
+        v = float(raw_scores[j])
+        total += v
+        sign = "+" if v >= 0 else ""
+        detail = _EV_MAP[j](row)
+        parts.append(f"{detail}({sign}{v:.0f})")
+    sign = "+" if total >= 0 else ""
+    parts.append(f"evolve_total={sign}{total:.0f}")
+    return "; ".join(parts)
+
+
+def run(input_path: str, output_csv: str | None = None, chunksize: int = 250_000,
+        gene_score_csv: str | None = None, ppi_score_csv: str | None = None):
+    t0 = time.time()
+    reg = default_registry()
+    theta = P12_V2_THETA
+    proj_cols = needed_columns(reg)
+
+    eng = available_engines()[0]
+    fmt = "parquet" if input_path.lower().endswith((".parquet", ".pq")) else "csv"
+    print(f"[pipeline] engine: {eng}  format: {fmt}")
+    print(f"[pipeline] input : {input_path}")
+    print(f"[pipeline] registry: {theta_keys(reg)}")
+
+    # ── PASS 1: project + score → vkey→(score,rank) lookup ──────────
+    print("[pass 1] scoring with column projection + selected_tx_only ...", flush=True)
+    F_parts, idx_parts = [], []
+    total, kept = 0, 0
+
+    pass1_engine = "pandas" if fmt == "csv" else eng
+    for chunk in iter_chunks(input_path, proj_cols, engine=pass1_engine, fmt=fmt,
+                             selected_tx_only=True, chunk_rows=chunksize):
+        total += len(chunk)
+        chunk = chunk.fillna("-")
+        recs = chunk.to_dict("records")
+        n, m = len(recs), len(reg)
+        F = np.zeros((n, m), dtype=float)
+        for j, c in enumerate(reg):
+            cal = c.calibrate
+            F[:, j] = [cal(r) for r in recs]
+        idx = pd.DataFrame({
+            "_order": np.arange(kept, kept + n),
+            "_vkey": [variant_key(r.get("chrom"), r.get("pos"), r.get("ref"), r.get("alt"))
+                      for r in recs],
+            "gene_symbol": [r.get("gene_symbol") for r in recs],
+            "_evidence": [_evidence_str(r, F[i, :], reg) for i, r in enumerate(recs)],
+        })
+        if "tx_rank_within_variant" in chunk.columns:
+            idx["tx_rank"] = [to_int(r.get("tx_rank_within_variant")) for r in recs]
+        F_parts.append(F)
+        idx_parts.append(idx)
+        kept += n
+        if kept % 2_000_000 < chunksize:
+            print(f"  [{time.strftime('%H:%M:%S')}] {kept:,} rows scored "
+                  f"({time.time()-t0:.0f}s)", flush=True)
+
+    print(f"[pass 1] {kept:,} rows → assembling features ({time.time()-t0:.0f}s)", flush=True)
+    F = np.vstack(F_parts) if len(F_parts) > 1 else F_parts[0]
+    idx_all = pd.concat(idx_parts, ignore_index=True)
+
+    bundle = FeatureBundle(F=F, keys=theta_keys(reg),
+                           kinds=[c.kind for c in reg],
+                           groups=[c.group for c in reg], index=idx_all)
+    scores = apply_theta(bundle, theta)
+    ranked = rank_units(bundle, scores, level="variant", collapse="auto")
+    print(f"[pass 1] ranked {len(ranked):,} variants ({time.time()-t0:.0f}s)", flush=True)
+
+    lookup_rows = []
+    for _, r in ranked.iterrows():
+        vk = r["_unit"]
+        # get evidence from the representative row (via _rep_row back to original idx)
+        rep_order = r.get("_rep_row", r.get("_order"))
+        evidence = idx_all.loc[idx_all["_order"] == rep_order, "_evidence"].values
+        evidence_str = str(evidence[0]) if len(evidence) else ""
+        lookup_rows.append({
+            "_vkey": f"{vk[0]}:{vk[1]}:{vk[2]}:{vk[3]}",
+            "evolve_score": float(r["score"]),
+            "evolve_rank": int(r["rank"]),
+            "_evidence": evidence_str,
+        })
+    lookup_df = pd.DataFrame(lookup_rows)
+    tmpdir = tempfile.mkdtemp()
+    lookup_path = f"{tmpdir}/scores.parquet"
+    lookup_df.to_parquet(lookup_path, index=False)
+    print(f"[pass 1] score lookup: {len(lookup_df):,} entries → {lookup_path} "
+          f"({time.time()-t0:.0f}s)", flush=True)
+
+    # ── PASS 2: duckdb SQL — filter, join, sort, export ──────────
+    if output_csv is None:
+        stem = Path(input_path).stem
+        output_csv = str(Path(input_path).parent / f"{stem}.ranked.csv")
+    else:
+        output_csv = str(output_csv)
+
+    print(f"[pass 2] duckdb sort+join → {output_csv}", flush=True)
+    import duckdb
+    con = duckdb.connect()
+
+    vk_expr = ("regexp_replace(CAST(chrom AS VARCHAR), '^[Cc][Hh][Rr]', '') || ':' || "
+               "CAST(pos AS VARCHAR) || ':' || "
+               "upper(CAST(ref AS VARCHAR)) || ':' || "
+               "upper(CAST(alt AS VARCHAR))")
+
+    if fmt == "csv":
+        src = (f"read_csv_auto('{input_path.replace(chr(39), chr(39)+chr(39))}', "
+               f"all_varchar=true, null_padding=true, ignore_errors=true, sample_size=-1)")
+    else:
+        src = f"read_parquet('{input_path.replace(chr(39), chr(39)+chr(39))}')"
+
+    schema_rows = con.execute(f"DESCRIBE SELECT * FROM {src}").fetchall()
+    schema_cols = [r[0] for r in schema_rows]
+    has_tx = "tx_rank_within_variant" in schema_cols
+
+    all_cols = [f'"{c}"' for c in schema_cols]
+    # exclude upstream columns we will overwrite
+    _exclude = []
+    for c in ("pathogenic_rank", "evidence_summary"):
+        if c in schema_cols:
+            _exclude.append(c)
+    proj_cols = [c for c in all_cols if c.strip('"') not in _exclude]
+    proj = ", ".join(proj_cols)
+    proj_with_key = f"{proj}, {vk_expr} AS _vkey"
+
+    where = ""
+    if has_tx:
+        where = "WHERE (CAST(tx_rank_within_variant AS VARCHAR) = '1' OR tx_rank_within_variant IS NULL)"
+
+    con.execute(f"CREATE OR REPLACE TABLE scores AS SELECT * FROM read_parquet('{lookup_path}')")
+
+    # ── optional gene-level score tables ──
+    pathogenic_expr = "s.evolve_score"
+    extra_joins = ""
+    extra_cols = ""
+
+    if gene_score_csv and os.path.exists(gene_score_csv):
+        gs_src = f"read_csv_auto('{gene_score_csv.replace(chr(39), chr(39)+chr(39))}', all_varchar=true)"
+        con.execute(f"CREATE OR REPLACE TABLE gene_scores AS SELECT gene_symbol, CAST(gene_score AS DOUBLE) AS gene_score FROM {gs_src}")
+        extra_joins += "\n        LEFT JOIN gene_scores gs ON src.gene_symbol = gs.gene_symbol"
+        gene_factor = "CASE WHEN gs.gene_score IS NULL THEN 1.0 WHEN gs.gene_score = 0 THEN 0.9 ELSE 1.0 + SQRT(gs.gene_score) END"
+        pathogenic_expr = f"s.evolve_score * ({gene_factor})"
+        extra_cols += ", gs.gene_score"
+        print("[pass 2] gene_score table loaded", flush=True)
+
+    if ppi_score_csv and os.path.exists(ppi_score_csv):
+        ppi_src = f"read_csv_auto('{ppi_score_csv.replace(chr(39), chr(39)+chr(39))}', all_varchar=true)"
+        con.execute(f"CREATE OR REPLACE TABLE ppi_scores AS SELECT gene, CAST(ppi_final AS DOUBLE) AS ppi_final FROM {ppi_src}")
+        extra_joins += "\n        LEFT JOIN ppi_scores ppi ON src.gene_symbol = ppi.gene"
+        ppi_factor = "CASE WHEN ppi.ppi_final IS NULL THEN 1.0 WHEN ppi.ppi_final = 0 THEN 0.9 ELSE 1.0 + SQRT(ppi.ppi_final) END"
+        pathogenic_expr = f"({pathogenic_expr}) * ({ppi_factor})"
+        extra_cols += ", ppi.ppi_final"
+        print("[pass 2] ppi_score table loaded", flush=True)
+
+    has_pathogenic = bool(gene_score_csv or ppi_score_csv)
+
+    # build evidence_summary: pass1 evidence + gene_boost + ppi_boost + pathogenic_total
+    _gene_f = "1.0"
+    _ppi_f = "1.0"
+    if gene_score_csv and os.path.exists(gene_score_csv):
+        _gene_f = gene_factor
+    if ppi_score_csv and os.path.exists(ppi_score_csv):
+        _ppi_f = ppi_factor
+
+    _insert = (
+        "'; gene_boost=x' || CAST(ROUND(COALESCE((" + _gene_f + "), 1.0), 2) AS VARCHAR) || "
+        "'; ppi_boost=x' || CAST(ROUND(COALESCE((" + _ppi_f + "), 1.0), 2) AS VARCHAR) || "
+        "'; evolve_total='"
+    )
+    evidence_expr = "REPLACE(s._evidence, '; evolve_total=', " + _insert + ")"
+    evidence_expr += (
+        " || '; pathogenic_total=' || CASE WHEN " + pathogenic_expr + " >= 0 THEN '+' ELSE '' END"
+        " || CAST(ROUND(" + pathogenic_expr + ", 1) AS VARCHAR)"
+    )
+
+    q = f"""
+    COPY (
+        SELECT src.*, s.evolve_score, s.evolve_rank{extra_cols},
+               {pathogenic_expr} AS pathogenic_score,
+               ROW_NUMBER() OVER (ORDER BY {pathogenic_expr} DESC NULLS LAST) AS pathogenic_rank,
+               {evidence_expr} AS evidence_summary
+        FROM (SELECT {proj_with_key} FROM {src} {where}) src
+        LEFT JOIN scores s ON src._vkey = s._vkey{extra_joins}
+        ORDER BY pathogenic_score DESC NULLS LAST
+    ) TO '{output_csv}' (HEADER, DELIMITER ',');
+    """
+    print(f"[pass 2] executing SQL sort+join+export ...", flush=True)
+    con.execute(q)
+    con.close()
+
+    total_time = time.time() - t0
+    print(f"[pipeline] done: {output_csv} ({total_time:.0f}s = {total_time/60:.1f} min)", flush=True)
+
+    verify_cols = ["evolve_score", "evolve_rank"]
+    if has_pathogenic:
+        verify_cols += ["pathogenic_score", "pathogenic_rank"]
+    if gene_score_csv and os.path.exists(gene_score_csv):
+        verify_cols.append("gene_score")
+    verify = pd.read_csv(output_csv, nrows=5, usecols=verify_cols)
+    for c in verify_cols:
+        print(f"  top {c}: {list(verify[c])}", flush=True)
+
+    return output_csv
+
+
+def main():
+    ap = argparse.ArgumentParser(description="rare_sort scoring pipeline (optimized)")
+    ap.add_argument("input_path", help="VEP CSV or Parquet file")
+    ap.add_argument("--output", "-o", default=None, help="output CSV path")
+    ap.add_argument("--chunksize", type=int, default=250_000,
+                    help="rows per chunk (default 250k)")
+    ap.add_argument("--gene-score", default=None, help="gene_phenotype_score.csv path")
+    ap.add_argument("--ppi-score", default=None, help="ppi_score.csv path")
+    args = ap.parse_args()
+    run(args.input_path, args.output, args.chunksize, args.gene_score, args.ppi_score)
+
+
+if __name__ == "__main__":
+    main()

--- a/pixi_rare_sort_fastapi/pixi.lock
+++ b/pixi_rare_sort_fastapi/pixi.lock
@@ -1,0 +1,2462 @@
+version: 7
+platforms:
+- name: osx-arm64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.4-h332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.138.0-h17c0fa6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.27-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.138.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.32-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.20.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.3.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.49.0-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.49.0-he2a8d16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.14.0-h7cba3ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.16.0-h16bb3af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastar-0.11.0-py314hbcbdb20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/httptools-0.8.0-py314h6c2aa35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h1fb9c8a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.11.3-h2431656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py314hb79c6fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.3-py314he609de1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-24.0.0-py314he55896b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-24.0.0-py314h109bba2_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py314h54f3292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.4-py314h4ed92d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvloop-0.22.1-py314h0612a62_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-1.2.0-py314he1d1ac0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-16.0-py314ha14b1ff_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+  sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
+  md5: 52be5139047efadaeeb19c6a5103f92a
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-doc?source=hash-mapping
+  run_exports: {}
+  size: 14222
+  timestamp: 1762868213144
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  md5: 2934f256a8acfe48f6ebb4fce6cde29c
+  depends:
+  - python >=3.9
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-types?source=hash-mapping
+  run_exports: {}
+  size: 18074
+  timestamp: 1733247158254
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+  md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10
+  - typing_extensions >=4.5
+  - python
+  constrains:
+  - trio >=0.32.0
+  - uvloop >=0.22.1
+  - winloop >=0.2.3
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/anyio?source=compressed-mapping
+  run_exports: {}
+  size: 161074
+  timestamp: 1781616881402
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+  md5: a9965dd99f683c5f444428f896635716
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  run_exports: {}
+  size: 128866
+  timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+  sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
+  md5: c13824fedced67005d3832c152fe9c2f
+  depends:
+  - python >=3.10
+  license: ISC
+  purls:
+  - pkg:pypi/certifi?source=compressed-mapping
+  run_exports: {}
+  size: 133877
+  timestamp: 1781719949728
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+  sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
+  md5: 554304a07e581a85891b15e39ea9f268
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/click?source=compressed-mapping
+  run_exports: {}
+  size: 104999
+  timestamp: 1779900548735
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
+  run_exports: {}
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
+  sha256: ef1e7b8405997ed3d6e2b6722bd7088d4a8adf215e7c88335582e65651fb4e05
+  md5: d73fdc05f10693b518f52c994d748c19
+  depends:
+  - python >=3.10,<4.0.0
+  - sniffio
+  - python
+  constrains:
+  - aioquic >=1.2.0
+  - cryptography >=45
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  - h2 >=4.2.0
+  - idna >=3.10
+  - trio >=0.30
+  - wmi >=1.5.1
+  license: ISC
+  purls:
+  - pkg:pypi/dnspython?source=hash-mapping
+  run_exports: {}
+  size: 196500
+  timestamp: 1757292856922
+- conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.4-h332efcf_0.conda
+  sha256: 5e83477e8ae38d093bf5743e283ecc4a519ddca37111e5932cc67e9a3d399149
+  md5: f51ca93d4a9729d2e0c388ccf612f325
+  depends:
+  - python-duckdb >=1.5.4,<1.5.5.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 7750
+  timestamp: 1781708666099
+- conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+  sha256: c37320864c35ef996b0e02e289df6ee89582d6c8e233e18dc9983375803c46bb
+  md5: 3bc0ac31178387e8ed34094d9481bfe8
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.10
+  license: Unlicense
+  purls:
+  - pkg:pypi/email-validator?source=hash-mapping
+  run_exports: {}
+  size: 46767
+  timestamp: 1756221480106
+- conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
+  sha256: 6a518e00d040fcad016fb2dde29672aa3476cd9ae33ea5b7b257222e66037d89
+  md5: 2452e434747a6b742adc5045f2182a8e
+  depends:
+  - email-validator >=2.3.0,<2.3.1.0a0
+  license: Unlicense
+  purls: []
+  run_exports: {}
+  size: 7077
+  timestamp: 1756221480651
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
+  md5: 8e662bd460bda79b1ea39194e3c4c9ab
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=hash-mapping
+  run_exports: {}
+  size: 21333
+  timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.138.0-h17c0fa6_0.conda
+  sha256: bbac6832be66344db8a7630546040e11545001eb1da496cb85aacd51e9aa963a
+  md5: 5b26b9a5c85c6f00216938ef392e5402
+  depends:
+  - fastapi-core ==0.138.0 pyhcf101f3_0
+  - email_validator
+  - fastapi-cli
+  - fastar
+  - httpx
+  - jinja2
+  - pydantic-extra-types
+  - pydantic-settings
+  - python-multipart
+  - uvicorn-standard
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 4846
+  timestamp: 1781963975265
+- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.27-pyhcf101f3_0.conda
+  sha256: da42816d85b9775ba03e47f5d395998655f61bbce4770a203024ffaf601ede09
+  md5: be7cfefffd8f38de299a0473621f03f7
+  depends:
+  - python >=3.10
+  - rich-toolkit >=0.14.8
+  - tomli >=2.0.0
+  - typer >=0.16
+  - uvicorn-standard >=0.15.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fastapi-cli?source=compressed-mapping
+  run_exports: {}
+  size: 19304
+  timestamp: 1781833514276
+- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.138.0-pyhcf101f3_0.conda
+  sha256: 6a2663f5ed07f053936af6f73d320fb693eeb5eb93bc6b5a2d1de6450fb59718
+  md5: 378b9bd4e47522ecd17e9b41a1b01028
+  depends:
+  - python >=3.10
+  - annotated-doc >=0.0.2
+  - starlette >=0.46.0
+  - typing_extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  - pydantic >=2.9.0
+  - python
+  constrains:
+  - email_validator >=2.0.0
+  - fastapi-cli >=0.0.8
+  - fastar >=0.9.0
+  - httpx >=0.23.0,<1.0.0
+  - jinja2 >=3.1.5
+  - pydantic-extra-types >=2.0.0
+  - pydantic-settings >=2.0.0
+  - python-multipart >=0.0.18
+  - uvicorn-standard >=0.12.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fastapi?source=hash-mapping
+  run_exports: {}
+  size: 102599
+  timestamp: 1781963975265
+- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+  sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
+  md5: b8993c19b0c32a2f7b66cbb58ca27069
+  depends:
+  - python >=3.10
+  - typing_extensions
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h11?source=hash-mapping
+  run_exports: {}
+  size: 39069
+  timestamp: 1767729720872
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+  sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
+  md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
+  depends:
+  - python >=3.10
+  - hyperframe >=6.1,<7
+  - hpack >=4.1,<5
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h2?source=hash-mapping
+  run_exports: {}
+  size: 95967
+  timestamp: 1756364871835
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+  sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+  md5: 0a802cb9888dd14eeefc611f05c40b6e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hpack?source=hash-mapping
+  run_exports: {}
+  size: 30731
+  timestamp: 1737618390337
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+  sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
+  md5: 4f14640d58e2cc0aa0819d9d8ba125bb
+  depends:
+  - python >=3.9
+  - h11 >=0.16
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=4.0,<5.0
+  - certifi
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/httpcore?source=hash-mapping
+  run_exports: {}
+  size: 49483
+  timestamp: 1745602916758
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  md5: d6989ead454181f4f9bc987d3dc4e285
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/httpx?source=hash-mapping
+  run_exports: {}
+  size: 63082
+  timestamp: 1733663449209
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+  sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
+  md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hyperframe?source=hash-mapping
+  run_exports: {}
+  size: 17397
+  timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+  sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
+  md5: 577b04680ae422adb86fc60d7b940659
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=compressed-mapping
+  run_exports: {}
+  size: 163869
+  timestamp: 1781620148226
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+  sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
+  md5: 04558c96691bed63104678757beb4f8d
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jinja2?source=hash-mapping
+  run_exports: {}
+  size: 120685
+  timestamp: 1764517220861
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 0c4c35376fe920714390d46e4b8d31c876d65f18e1655899e0763ec25f2a902f
+  md5: 6d03368f2b2b0a5fb6839df53b2eb5e0
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/markdown-it-py?source=hash-mapping
+  run_exports: {}
+  size: 69017
+  timestamp: 1778169663339
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mdurl?source=hash-mapping
+  run_exports: {}
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+  sha256: 69700e31165df070e9716315e042196aa92525dae5deb5107785847ab9f4189f
+  md5: 729843edafc0899b3348bd3f19525b9d
+  depends:
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  - python >=3.10
+  - annotated-types >=0.6.0
+  - pydantic-core ==2.46.4
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic?source=hash-mapping
+  run_exports: {}
+  size: 346511
+  timestamp: 1778103405862
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
+  sha256: 385a900cf5d1d39dafab6088537c58a32d572fd237d7c4598def92c4c1120cb8
+  md5: 96513760035d70917819a2840155d23a
+  depends:
+  - python >=3.10
+  - pydantic >=2.5.2
+  - python
+  constrains:
+  - phonenumbers >=8,<9
+  - pycountry >=23
+  - semver >=3.0.2,<4
+  - python-ulid >=1,<4
+  - pendulum >=3.0.0,<4.0.0
+  - pytz >=2024.1
+  - tzdata >=2024a
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-extra-types?source=hash-mapping
+  run_exports: {}
+  size: 72040
+  timestamp: 1773664659868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
+  sha256: de1eb2cdb22a678387ec7757f10b7815c4c2a4d62f23b2a70fe4beff7e8a1fd4
+  md5: a1c5305893d9956abd2079d377c5113f
+  depends:
+  - typing-inspection >=0.4.0
+  - python >=3.10
+  - pydantic >=2.7.0
+  - python-dotenv >=0.21.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-settings?source=compressed-mapping
+  run_exports: {}
+  size: 52920
+  timestamp: 1781884990751
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
+  md5: 16c18772b340887160c79a6acc022db0
+  depends:
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=hash-mapping
+  run_exports: {}
+  size: 893031
+  timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+  md5: 5b8d21249ff20967101ffa321cab24e8
+  depends:
+  - python >=3.9
+  - six >=1.5
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/python-dateutil?source=hash-mapping
+  run_exports: {}
+  size: 233310
+  timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
+  sha256: 74e417a768f59f02a242c25e7db0aa796627b5bc8c818863b57786072aeb85e5
+  md5: 130584ad9f3a513cdd71b1fdc1244e9c
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/python-dotenv?source=hash-mapping
+  run_exports: {}
+  size: 27848
+  timestamp: 1772388605021
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.32-pyhcf101f3_0.conda
+  sha256: 7dde902994a99993b616d597783fcd0ce3265a550feffbd0890b1329c9dff7e0
+  md5: f54d00b369042e8e0e235b1a1a817487
+  depends:
+  - python >=3.10
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/python-multipart?source=compressed-mapping
+  run_exports: {}
+  size: 38132
+  timestamp: 1780610429919
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6989
+  timestamp: 1752805904792
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+  sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
+  md5: 0242025a3c804966bf71aa04eee82f66
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.10
+  - typing_extensions >=4.0.0,<5.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rich?source=hash-mapping
+  run_exports: {}
+  size: 208577
+  timestamp: 1775991661559
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.20.1-pyhcf101f3_0.conda
+  sha256: e29d6b7138aca5e0773462c07bbafd707f8fe9763f95d811ccd4394ac0f262ff
+  md5: e7cc7bf579daf5fa80338c1efe41b62b
+  depends:
+  - python >=3.10
+  - rich >=13.7.1
+  - click >=8.1.7
+  - typing_extensions >=4.12.2
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rich-toolkit?source=compressed-mapping
+  run_exports: {}
+  size: 34331
+  timestamp: 1780659356824
+- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
+  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/shellingham?source=hash-mapping
+  run_exports: {}
+  size: 15018
+  timestamp: 1762858315311
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+  sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
+  md5: 3339e3b65d58accf4ca4fb8748ab16b3
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/six?source=hash-mapping
+  run_exports: {}
+  size: 18455
+  timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+  sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
+  md5: 03fe290994c5e4ec17293cfb6bdce520
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/sniffio?source=hash-mapping
+  run_exports: {}
+  size: 15698
+  timestamp: 1762941572482
+- conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.3.1-pyhcf101f3_0.conda
+  sha256: 17e3dc37c0ac9754b782e49285a3d8d223d372f7012d64a4f6ae371466cef143
+  md5: bb8e15a6ef1a475545720fa2c29f19c4
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.10
+  - typing_extensions >=4.10.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/starlette?source=compressed-mapping
+  run_exports: {}
+  size: 64264
+  timestamp: 1781447071524
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=hash-mapping
+  run_exports: {}
+  size: 21561
+  timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+  sha256: 15dce0fa9d2a5077755c0ae98b3b521a9409b9468a0597ce697940fb035e5b67
+  md5: 71d2c80673511fab927bd15592994030
+  depends:
+  - annotated-doc >=0.0.2
+  - colorama
+  - python >=3.10
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  - python
+  license: MIT AND BSD-3-Clause
+  purls:
+  - pkg:pypi/typer?source=hash-mapping
+  run_exports: {}
+  size: 185949
+  timestamp: 1780494828822
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+  sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
+  md5: edd329d7d3a4ab45dcf905899a7a6115
+  depends:
+  - typing_extensions ==4.15.0 pyhcf101f3_0
+  license: PSF-2.0
+  license_family: PSF
+  purls: []
+  run_exports: {}
+  size: 91383
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+  sha256: 8b90d2f19f9458b8c58a55e1fcdc1d90c1603a847a47654d8a454549413ba60a
+  md5: 53f5409c5cfd6c5a66417d68e3f0a864
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.12.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typing-inspection?source=hash-mapping
+  run_exports: {}
+  size: 20935
+  timestamp: 1777105465795
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
+  run_exports: {}
+  size: 51692
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  md5: ad659d0a2b3e47e38d829aa8cad2d610
+  license: LicenseRef-Public-Domain
+  purls: []
+  run_exports: {}
+  size: 119135
+  timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.49.0-pyhc90fa1f_0.conda
+  sha256: dc7477d200432bf07aab5218d305d88771c52fb8d449cf82869cdceae291f100
+  md5: 29a950390b7de7577d8c0ebc946055b9
+  depends:
+  - __unix
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.10
+  - typing_extensions >=4.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/uvicorn?source=hash-mapping
+  run_exports: {}
+  size: 56228
+  timestamp: 1780574319325
+- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.49.0-he2a8d16_0.conda
+  sha256: c5d67cef56cf9b3329d236ca4c05ab74495a9bbcae9e466793ae687dadc9aac4
+  md5: d289039d3680e8041e0e9b6960e9aa0d
+  depends:
+  - __unix
+  - uvicorn ==0.49.0 pyhc90fa1f_0
+  - websockets >=10.4
+  - httptools >=0.6.3
+  - watchfiles >=0.20
+  - python-dotenv >=0.13
+  - pyyaml >=5.1
+  - uvloop >=0.15.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 4149
+  timestamp: 1780574319325
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  build_number: 7
+  sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
+  md5: a44032f282e7d2acdeb1c240308052dd
+  depends:
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - _openmp_mutex >=4.5
+  size: 8325
+  timestamp: 1764092507920
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
+  sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
+  md5: 1fc365a60432d78b729d1468fce1b6c9
+  depends:
+  - __osx >=11.0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-auth >=0.10.3,<0.10.4.0a0
+  size: 116705
+  timestamp: 1781803055465
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
+  sha256: 557bc47cbfd01dc569b930c102cd56ca5ba67750bd51a4fcee445246e7e536cd
+  md5: dcac0aa854a1f7f58a59226f5309a44e
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-cal >=0.9.14,<0.9.15.0a0
+  size: 45764
+  timestamp: 1780567235337
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
+  sha256: 223f67551038366555e6934802d8b375547b142157aad3fc3654c720ac1525c0
+  md5: 3a49923f2b3987a833a264caca603f84
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-common >=0.14.0,<0.14.1.0a0
+  size: 226438
+  timestamp: 1780161234587
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
+  sha256: 4289ff476103d109623bd413b12d61307d6267e87fc6a8c29b0aec71dfa8fd84
+  md5: 497edff11fcb32865d8c5d6ab3aef6e0
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-compression >=0.3.2,<0.3.3.0a0
+  size: 21529
+  timestamp: 1780566290492
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
+  sha256: 5e0c69837e21fc17cc26ad6c252e842a96bb16f5be2c6f06f48a13b8a56fc56f
+  md5: 608685880a69722c685d1729c57409f6
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  size: 53730
+  timestamp: 1780586998748
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
+  sha256: 06d3b08ed19cd63fd75750e325f19ebf7183b22ee27cbe2ca7b7dd6725d34885
+  md5: f0fc8139091eb8245209bb9ee8911a82
+  depends:
+  - __osx >=11.0
+  - aws-c-compression >=0.3.2,<0.3.3.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-http >=0.11.0,<0.11.1.0a0
+  size: 177282
+  timestamp: 1780586850553
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
+  sha256: 82b51f24e391dcf4750a238ed84368e09bf00c8295d0206e92e85cc78ef3a3b9
+  md5: 3f3d6b053bc85cf224ac53ee8a32fcf0
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-io >=0.26.3,<0.26.4.0a0
+  size: 176911
+  timestamp: 1781649841117
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+  sha256: 311a2051eb2e48664229a9b10886013c4c059aef602b70909ac1bc8d2000fc6d
+  md5: 23ef6506ce17c3ed79db869898f99598
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  size: 158010
+  timestamp: 1780681916713
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+  sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
+  md5: 912c61c44a2782693d63af2272551455
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 132571
+  timestamp: 1781253082057
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
+  sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
+  md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 58773
+  timestamp: 1781798801665
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
+  sha256: 9af1483700bb29870297e2390838d3c31293e8cf80fd8a8a9bd9a1446020a8d8
+  md5: 7c5f6a6efce80e728c1f743e064ab657
+  depends:
+  - __osx >=11.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-checksums >=0.2.10,<0.2.11.0a0
+  size: 91975
+  timestamp: 1780568646105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+  sha256: 6d2b0bf67403c53f6954b7602e529cac91b1d156b22f71db5d97bf9ebc269790
+  md5: 602dd44df5dd28061de3ee798e991b42
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  size: 275202
+  timestamp: 1781814158495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
+  sha256: 48a47f63331523fdf56502ae2c820c56b9d83b576c71c980372825d179b5db65
+  md5: 28a22c86c0819985c291dbde9dbe548a
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
+  size: 3261003
+  timestamp: 1781874466880
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
+  sha256: 9645073c4682ad3a334a2b06c5fc0ddc57fc9f0f537cc3123053634c92c28625
+  md5: 4f42d997f42a8d34ff74cb677cf0c828
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.19.0,<9.0a0
+  - libcxx >=19
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  size: 290309
+  timestamp: 1775239330289
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
+  sha256: d950fb513311a15cd4ae663cdacb2c035122f609a9c790973661b38e0882e40e
+  md5: e1701f6b2ce6f47aeb6cbfab132403d8
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  - libcxx >=19
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - azure-identity-cpp >=1.13.3,<1.13.4.0a0
+  size: 168032
+  timestamp: 1781268747743
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
+  sha256: 3f096d7cd6fd7788d57887c3d3e48be1ebc5c3a971666ddc0dd8a3493a5b7cb5
+  md5: 0948246cb8e514e4ae1cfe7dbb4046c7
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
+  - libcxx >=19
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
+  size: 436462
+  timestamp: 1781284116423
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.14.0-h7cba3ab_1.conda
+  sha256: 9a1b6e5284f1f242330dfa1e21408ffd823a76df424108d8c319c2a46df61dba
+  md5: 2af5d1b5365c4a3de8ed8ec8438fe6ec
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
+  size: 128710
+  timestamp: 1781268693348
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.16.0-h16bb3af_1.conda
+  sha256: fb210d8d068df72a68c5fa655cf1f816792e278da3041c485478e7924d6e80eb
+  md5: 06ba52b8a66fd041f4910b547e3f3da1
+  depends:
+  - __osx >=11.0
+  - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  - azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
+  - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
+  - libcxx >=19
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
+  size: 206698
+  timestamp: 1781541197750
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
+  md5: 620b85a3f45526a8bc4d23fd78fc22f0
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 124834
+  timestamp: 1771350416561
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+  sha256: 2995f2aed4e53725e5efbc28199b46bf311c3cab2648fc4f10c2227d6d5fa196
+  md5: bcb3cba70cf1eec964a03b4ba7775f01
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.6,<2.0a0
+  size: 180327
+  timestamp: 1765215064054
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastar-0.11.0-py314hbcbdb20_0.conda
+  sha256: 39e1a0e2f73851bdf5cbda4acf81275f523d8eb46b2636ce02d89c9fd0e18701
+  md5: 37067a410589437e9e62d95f2b28196b
+  depends:
+  - python
+  - __osx >=11.0
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fastar?source=hash-mapping
+  run_exports: {}
+  size: 380351
+  timestamp: 1776177849422
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - gflags >=2.2.2,<2.3.0a0
+  size: 82090
+  timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+  sha256: 9fc77de416953aa959039db72bc41bfa4600ae3ff84acad04a7d0c1ab9552602
+  md5: fef68d0a95aa5b84b5c1a4f6f3bf40e1
+  depends:
+  - __osx >=11.0
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - glog >=0.7.1,<0.8.0a0
+  size: 112215
+  timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/httptools-0.8.0-py314h6c2aa35_0.conda
+  sha256: 1a8d246a4dd22e16b5c37d8d5f3efaf8d2dd566629c790c29cf8e2a5d89c5208
+  md5: 930eb3505f8de78940ef851f388943f4
+  depends:
+  - __osx >=11.0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/httptools?source=hash-mapping
+  run_exports: {}
+  size: 92492
+  timestamp: 1779757914778
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
+  md5: f1182c91c0de31a7abd40cedf6a5ebef
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 12361647
+  timestamp: 1773822915649
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+  sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
+  md5: 8780f41b013d19219faef9c82260744b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1159780
+  timestamp: 1781859501654
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
+  sha256: 756611fbb8d2957a5b4635d9772bd8432cb6ddac05580a6284cca6fdc9b07fca
+  md5: bb65152e0d7c7178c0f1ee25692c9fd1
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  constrains:
+  - abseil-cpp =20260107.1
+  - libabseil-static =20260107.1=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - libabseil >=20260107.1,<20260108.0a0
+    - libabseil =*=cxx17*
+  size: 1229639
+  timestamp: 1770863511331
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+  build_number: 8
+  sha256: 3fb75f077b1b1a2fc577e96c7c7bbb149c38819c3807795d4919fdfbf4d35f9e
+  md5: f4c6a48b3bf53c59a0f3ee5f5b492c62
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
+  - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  - azure-identity-cpp >=1.13.3,<1.13.4.0a0
+  - azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
+  - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libcxx >=21
+  - libgoogle-cloud >=3.6.0,<3.7.0a0
+  - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - orc >=2.3.0,<2.3.1.0a0
+  - snappy >=1.2.2,<1.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  purls: []
+  run_exports:
+    weak:
+    - libarrow >=24.0.0,<24.1.0a0
+  size: 4262820
+  timestamp: 1782184446658
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+  build_number: 8
+  sha256: 46c20e39c6104cba3c74c781671933ccdebb958131003ff61d50a552e0b8f8e6
+  md5: 39a30fa1ac563d314ea65741e6761739
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libarrow-compute 24.0.0 h8d10c55_8_cpu
+  - libcxx >=21
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  license: Apache-2.0
+  purls: []
+  run_exports:
+    weak:
+    - libarrow-acero >=24.0.0,<24.1.0a0
+  size: 519849
+  timestamp: 1782184880774
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+  build_number: 8
+  sha256: 9f73c59cfbe680f0328098f20e4116df36b45484a204743813ebec03e8a70a2a
+  md5: 8d9f3dc3909108ddf4bc5411623b2ccc
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libcxx >=21
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5
+  - libutf8proc >=2.11.3,<2.12.0a0
+  - re2
+  license: Apache-2.0
+  purls: []
+  run_exports:
+    weak:
+    - libarrow-compute >=24.0.0,<24.1.0a0
+  size: 2243840
+  timestamp: 1782184563897
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+  build_number: 8
+  sha256: d1db32a0d814236188945bee083e49d578dc0b35715367c5823b7125d7aeee25
+  md5: f22bc2e04525bee90f5e89c2661f796f
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libarrow-acero 24.0.0 ha4f4840_8_cpu
+  - libarrow-compute 24.0.0 h8d10c55_8_cpu
+  - libcxx >=21
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libparquet 24.0.0 h840b369_8_cpu
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  license: Apache-2.0
+  purls: []
+  run_exports:
+    weak:
+    - libarrow-dataset >=24.0.0,<24.1.0a0
+  size: 518870
+  timestamp: 1782185056190
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
+  build_number: 8
+  sha256: 1ae21b67f081aea9f136141b95691e2e98596ab733bbc261577f998dd08f88bf
+  md5: 6d82f177aff9e47fed86ae793318b4ad
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libarrow-acero 24.0.0 ha4f4840_8_cpu
+  - libarrow-dataset 24.0.0 ha4f4840_8_cpu
+  - libcxx >=21
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  license: Apache-2.0
+  purls: []
+  run_exports:
+    weak:
+    - libarrow-substrait >=24.0.0,<24.1.0a0
+  size: 454799
+  timestamp: 1782185112950
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+  build_number: 8
+  sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
+  md5: dbfe729181a32741ae63ecb41eefbac6
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  - libcblas   3.11.0   8*_openblas
+  - mkl <2027
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18949
+  timestamp: 1779859141315
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
+  sha256: a7cb9e660531cf6fbd4148cff608c85738d0b76f0975c5fc3e7d5e92840b7229
+  md5: 006e7ddd8a110771134fcc4e1e3a6ffa
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libbrotlicommon >=1.2.0,<1.3.0a0
+  size: 79443
+  timestamp: 1764017945924
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
+  sha256: 2eae444039826db0454b19b52a3390f63bfe24f6b3e63089778dd5a5bf48b6bf
+  md5: 079e88933963f3f149054eec2c487bc2
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.2.0 hc919400_1
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libbrotlidec >=1.2.0,<1.3.0a0
+  size: 29452
+  timestamp: 1764017979099
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
+  sha256: 01436c32bb41f9cb4bcf07dda647ce4e5deb8307abfc3abdc8da5317db8189d1
+  md5: b2b7c8288ca1a2d71ff97a8e6a1e8883
+  depends:
+  - __osx >=11.0
+  - libbrotlicommon 1.2.0 hc919400_1
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libbrotlienc >=1.2.0,<1.3.0a0
+  size: 290754
+  timestamp: 1764018009077
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+  build_number: 8
+  sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
+  md5: 03a2ef3491da9e5b4d18c03e9f4b3109
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 18911
+  timestamp: 1779859147634
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libcrc32c >=1.1.2,<1.2.0a0
+  size: 18765
+  timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+  md5: 2f57b7d0c6adda88957586b7afd78438
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.20.0,<9.0a0
+  size: 400568
+  timestamp: 1777462251987
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
+  md5: 89f76a2a21a3ec3ec983b5eb237c4113
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  run_exports: {}
+  size: 569349
+  timestamp: 1781670209146
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+  md5: 44083d2d2c2025afca315c7a172eab2b
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 107691
+  timestamp: 1738479560845
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libevent >=2.1.12,<2.1.13.0a0
+  size: 368167
+  timestamp: 1685726248899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  md5: a915151d5d3c5bf039f5ccc8402a436f
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 69362
+  timestamp: 1781203631990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
+  md5: 43c04d9cb46ef176bb2a4c77e324d599
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.5.2,<3.6.0a0
+  size: 40979
+  timestamp: 1769456747661
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+  sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
+  md5: 644058123986582db33aebd4ae2ca184
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 404080
+  timestamp: 1778273064154
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+  sha256: d4837b3b9b30af3132d260225e91ab9dde83be04c59513f500cc81050fb37486
+  md5: 1ea03f87cdb1078fbc0e2b2deb63752c
+  depends:
+  - libgfortran5 15.2.0 hdae7583_19
+  constrains:
+  - libgfortran-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 139675
+  timestamp: 1778273280875
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+  sha256: d0a68b7a121d115b80c169e24d1265dcc25a3fe58d107df1bbc430797e226d88
+  md5: ba36d8c606a6a53fe0b8c12d47267b3d
+  depends:
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 599691
+  timestamp: 1778273075448
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+  sha256: 650f0605bed3048ca69b547cc31e1d6c70b7371fb3212b00b103da6fd2f11d77
+  md5: be005bcbd77890a199ee583ba7a74bec
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libcxx >=19
+  - libgrpc >=1.78.1,<1.79.0a0
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - openssl >=3.5.7,<4.0a0
+  constrains:
+  - libgoogle-cloud 3.6.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - libgoogle-cloud >=3.6.0,<3.7.0a0
+  size: 1839082
+  timestamp: 1781921657626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
+  sha256: a01821942ab88a433a81ec9a0e6aa72ed5f7ceb5e11a295f3eb28dd22a0a24bf
+  md5: b7c9ec99242e620133106438ccfcf08e
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=19
+  - libgoogle-cloud 3.6.0 h688a705_0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
+  size: 528490
+  timestamp: 1781921815114
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
+  sha256: a6e01573795484c2200e499ddffb825d24184888be6a596d4beaceebe6f8f525
+  md5: 17b9e07ba9b46754a6953999a948dcf7
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.6,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcxx >=19
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libre2-11 >=2025.11.5
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.78.1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - libgrpc >=1.78.1,<1.79.0a0
+  size: 4820402
+  timestamp: 1774012715207
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
+  md5: 4d5a7445f0b25b6a3ddbb56e790f5251
+  depends:
+  - __osx >=11.0
+  license: LGPL-2.1-only
+  purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 750379
+  timestamp: 1754909073836
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+  build_number: 8
+  sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
+  md5: 85adeb3d469d082dbd9c8c39e36dec57
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - libcblas   3.11.0   8*_openblas
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18925
+  timestamp: 1779859153970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+  md5: b1fd823b5ae54fbec272cea0811bd8a9
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 92472
+  timestamp: 1775825802659
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+  sha256: 1089c7f15d5b62c622625ec6700732ece83be8b705da8c6607f4dabb0c4bd6d2
+  md5: 57c4be259f5e0b99a5983799a228ae55
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 73690
+  timestamp: 1769482560514
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+  sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
+  md5: 6ea18834adbc3b33df9bd9fb45eaf95b
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.6,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 576526
+  timestamp: 1773854624224
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+  sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
+  md5: 909e41855c29f0d52ae630198cd57135
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.33,<0.3.34.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libopenblas >=0.3.33,<1.0a0
+  size: 4304965
+  timestamp: 1776995497368
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
+  sha256: db60a4d6eb5be208f8a0be686909b1f10635b3913a7c1ce391d4d26d991115c3
+  md5: 35e93c8c0edb8dff7f9ebeb55ec4e6a6
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgrpc >=1.78.1,<1.79.0a0
+  - libopentelemetry-cpp-headers 1.27.0 hce30654_0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - nlohmann_json
+  - prometheus-cpp >=1.3.0,<1.4.0a0
+  constrains:
+  - cpp-opentelemetry-sdk =1.27.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  size: 582427
+  timestamp: 1778721505645
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
+  sha256: 64724bf5c5c48ecbc92a7d561654c6305d6dc819e0773c8989877f0613e52542
+  md5: f8039fbb88b31890de23c8a16ae03d92
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports: {}
+  size: 394303
+  timestamp: 1778721455052
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
+  build_number: 8
+  sha256: 1c09305b9799442be75ece3565ea9b25195fe7d8d038d68a483f55c70037b620
+  md5: d1c458dee7223a02a095c27b86fa6fea
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libcxx >=21
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libthrift >=0.22.0,<0.22.1.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: Apache-2.0
+  purls: []
+  run_exports:
+    weak:
+    - libparquet >=24.0.0,<24.1.0a0
+  size: 1098749
+  timestamp: 1782184832374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
+  sha256: 416c2244999d678dc9a4d8c3472336f8f754676125605399cf6e43956fa3d18b
+  md5: 300fdae9d7ad150a90755f55b0a8a7a8
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcxx >=19
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libprotobuf >=6.33.5,<6.33.6.0a0
+  size: 2768714
+  timestamp: 1780004273744
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
+  sha256: 1e2d23bbc1ffca54e4912365b7b59992b7ae5cbeb892779a6dcd9eca9f71c428
+  md5: 40d8ad21be4ccfff83a314076c3563f4
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libcxx >=19
+  constrains:
+  - re2 2025.11.05.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libre2-11 >=2025.11.5
+  size: 165851
+  timestamp: 1768190225157
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+  md5: 1ebde5c677f00765233a17e278571177
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.2,<4.0a0
+  size: 927724
+  timestamp: 1780575223548
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+  sha256: 8bfe837221390ffc6f111ecca24fa12d4a6325da0c8d131333d63d6c37f27e0a
+  md5: b68e8f66b94b44aaa8de4583d3d4cc40
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 279193
+  timestamp: 1745608793272
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h1fb9c8a_2.conda
+  sha256: 568bb23db02b050c3903bec05edbcab84960c8c7e5a1710dac3109df997ac7f1
+  md5: d006875f9a58a44f92aec9a7ebeb7150
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - libthrift >=0.22.0,<0.22.1.0a0
+  size: 323017
+  timestamp: 1777019893083
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.11.3-h2431656_0.conda
+  sha256: ae1a82e62cd4e3c18e005ae7ff4358ed72b2bfbfe990d5a6a5587f81e9a100dc
+  md5: 2255add2f6ae77d0a96624a5cbde6d45
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libutf8proc >=2.11.3,<2.12.0a0
+  size: 87916
+  timestamp: 1768735311947
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_0.conda
+  sha256: e23176af832f637693ebbb9bbe7d29c0f4cba662dabd001081d2aa6fc9f7f661
+  md5: fa9fef7d9f33724b7c3899c883c25a3e
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 122732
+  timestamp: 1779396113397
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
+  sha256: ff75b84cdb9e8d123db2fa694a8ac2c2059516b6cbc98ac21fb68e235d0fd354
+  md5: 19edaa53885fc8205614b03da2482282
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - libxml2 2.15.3
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 466360
+  timestamp: 1776377102261
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
+  sha256: 2fe1d8de0854342ae9cabe408b476935f82f5636e153b3b497456264dc8ff3a1
+  md5: 8e037d73747d6fe34e12d7bcac10cf21
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 h5ef1a60_0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
+  size: 41102
+  timestamp: 1776377119495
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 47759
+  timestamp: 1774072956767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+  sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
+  md5: a9c118f6343fb6301b6f3b4e94c4c562
+  depends:
+  - __osx >=11.0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 22.1.8|22.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  run_exports:
+    strong:
+    - llvm-openmp >=22.1.8
+  size: 286313
+  timestamp: 1781736516782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+  sha256: 94d3e2a485dab8bdfdd4837880bde3dd0d701e2b97d6134b8806b7c8e69c8652
+  md5: 01511afc6cc1909c5303cf31be17b44f
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - lz4-c >=1.10.0,<1.11.0a0
+  size: 148824
+  timestamp: 1733741047892
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
+  sha256: 411153d14ee0d98be6e3751cf5cc0502db17bce2deebebb8779e33d29d0e525f
+  md5: d33c0a15882b70255abdd54711b06a45
+  depends:
+  - __osx >=11.0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  run_exports: {}
+  size: 27256
+  timestamp: 1772445397216
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+  md5: 343d10ed5b44030a2f67193905aea159
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 805509
+  timestamp: 1777423252320
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
+  sha256: 1945fd5b64b74ef3d57926156fb0bfe88ee637c49f3273067f7231b224f1d26d
+  md5: 755cfa6c08ed7b7acbee20ccbf15a47c
+  constrains:
+  - nlohmann_json-abi ==3.12.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 137595
+  timestamp: 1768670878127
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py314hb79c6fa_0.conda
+  sha256: dfd260fce05ff833ac121a1b1e4aa22d9c346a781c1e883dd871338cc1d9f8b0
+  md5: 5283d56d01517fa1780c72f2544e8603
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - libblas >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - liblapack >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=compressed-mapping
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 7123654
+  timestamp: 1782112549976
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
+  md5: 8187a86242741725bfa74785fe812979
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3102584
+  timestamp: 1781069820667
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
+  sha256: 8594f064828cca9b8d625e2ebe79436fd4ffc030c950573380c54a8f4329f955
+  md5: 77bfe521901c1a247cc66c1276826a85
+  depends:
+  - tzdata
+  - libcxx >=19
+  - __osx >=11.0
+  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - snappy >=1.2.2,<1.3.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libabseil >=20260107.1,<20260108.0a0
+  - libabseil * cxx17*
+  - lz4-c >=1.10.0,<1.11.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports:
+    weak:
+    - orc >=2.3.0,<2.3.1.0a0
+  size: 548180
+  timestamp: 1773230270828
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.3-py314he609de1_0.conda
+  sha256: 90d84a2a6e7e9826f28f71ff34c7daacd0819c96eb3951f1ab59ef460a75fb58
+  md5: 703276fc0e3693ff6a7566f1ac6865ab
+  depends:
+  - python
+  - numpy >=1.26.0
+  - python-dateutil >=2.8.2
+  - libcxx >=19
+  - python 3.14.* *_cp314
+  - __osx >=11.0
+  - python_abi 3.14.* *_cp314
+  - numpy >=1.23,<3
+  constrains:
+  - adbc-driver-postgresql >=1.2.0
+  - adbc-driver-sqlite >=1.2.0
+  - beautifulsoup4 >=4.12.3
+  - blosc >=1.21.3
+  - bottleneck >=1.4.2
+  - fastparquet >=2024.11.0
+  - fsspec >=2024.10.0
+  - gcsfs >=2024.10.0
+  - html5lib >=1.1
+  - hypothesis >=6.116.0
+  - jinja2 >=3.1.5
+  - lxml >=5.3.0
+  - matplotlib >=3.9.3
+  - numba >=0.60.0
+  - numexpr >=2.10.2
+  - odfpy >=1.4.1
+  - openpyxl >=3.1.5
+  - psycopg2 >=2.9.10
+  - pyarrow >=13.0.0
+  - pyiceberg >=0.8.1
+  - pymysql >=1.1.1
+  - pyqt5 >=5.15.9
+  - pyreadstat >=1.2.8
+  - pytables >=3.10.1
+  - pytest >=8.3.4
+  - pytest-xdist >=3.6.1
+  - python-calamine >=0.3.0
+  - pytz >=2024.2
+  - pyxlsb >=1.0.10
+  - qtpy >=2.4.2
+  - scipy >=1.14.1
+  - s3fs >=2024.10.0
+  - sqlalchemy >=2.0.36
+  - tabulate >=0.9.0
+  - xarray >=2024.10.0
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.2.0
+  - zstandard >=0.23.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pandas?source=hash-mapping
+  run_exports: {}
+  size: 14368928
+  timestamp: 1778602917992
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
+  sha256: 851a77ae1a8e90db9b9f3c4466abea7afb52713c3d98ceb0d37ba6ff27df2eff
+  md5: 7172339b49c94275ba42fec3eaeda34f
+  depends:
+  - __osx >=11.0
+  - libcurl >=8.10.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - prometheus-cpp >=1.3.0,<1.4.0a0
+  size: 173220
+  timestamp: 1730769371051
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-24.0.0-py314he55896b_0.conda
+  sha256: af8d6775f7ba3642cbc6bd13fcd5964269d4f36ffe00ee6b54161471aeea27f8
+  md5: be8e7739464185154f706560c30ced52
+  depends:
+  - libarrow-acero 24.0.0.*
+  - libarrow-dataset 24.0.0.*
+  - libarrow-substrait 24.0.0.*
+  - libparquet 24.0.0.*
+  - pyarrow-core 24.0.0 *_0_*
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  run_exports: {}
+  size: 26896
+  timestamp: 1776928739464
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-24.0.0-py314h109bba2_0_cpu.conda
+  sha256: d8ed966420d2ede8b3cefc2fc831b3d6ff6f111e2309feed660e1a3db4b536c7
+  md5: 9282fb072642aa9d8242f906532504fa
+  depends:
+  - __osx >=11.0
+  - libarrow 24.0.0.* *cpu
+  - libarrow-compute 24.0.0.* *cpu
+  - libcxx >=21
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - apache-arrow-proc * cpu
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/pyarrow?source=hash-mapping
+  run_exports: {}
+  size: 4334926
+  timestamp: 1776928703378
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.4-py314h54f3292_0.conda
+  sha256: c034a7cc16f279c260d3456fcfc625838495a7f9f55aa79408a629a427769bb2
+  md5: 16314d88257820013e698381af19153f
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  run_exports: {}
+  size: 1722694
+  timestamp: 1778084354332
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
+  build_number: 100
+  sha256: 984081c9fae3a3944c6f2707bbbbc70e8b961f02cdb7c640d9745e2636235632
+  md5: 4841be3d0cf616a860efc6e60af66f8b
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 14059371
+  timestamp: 1781254578985
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.4-py314h4ed92d5_0.conda
+  sha256: 16f4fd4031d04b6c47795d745ec4e51eed1de6cc55cf49a7894cdd6ee6965331
+  md5: 07a6fb723397bf0c1862cfb63e1f3844
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/duckdb?source=hash-mapping
+  run_exports: {}
+  size: 12067906
+  timestamp: 1781709963645
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
+  sha256: 95f385f9606e30137cf0b5295f63855fd22223a4cf024d306cf9098ea1c4a252
+  md5: dcf51e564317816cb8d546891019b3ab
+  depends:
+  - __osx >=11.0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  run_exports: {}
+  size: 189475
+  timestamp: 1770223788648
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
+  sha256: 5bab972e8f2bff1b5b3574ffec8ecb89f7937578bd107584ed3fde507ff132f9
+  md5: a1ff22f664b0affa3de712749ccfbf04
+  depends:
+  - libre2-11 2025.11.05 h4c27e2a_1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libre2-11 >=2025.11.5
+    - re2
+  size: 27445
+  timestamp: 1768190259003
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
+  md5: f8381319127120ce51e081dce4865cf4
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 313930
+  timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
+  sha256: cb9305ede19584115f43baecdf09a3866bfcd5bcca0d9e527bd76d9a1dbe2d8d
+  md5: fca4a2222994acd7f691e57f94b750c5
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - snappy >=1.2.2,<1.3.0a0
+  size: 38883
+  timestamp: 1762948066818
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
+  md5: a9d86bc62f39b94c4661716624eb21b0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3127137
+  timestamp: 1769460817696
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvloop-0.22.1-py314h0612a62_1.conda
+  sha256: 7850dd9238beb14f9c7db1901229cc5d2ecd10d031cbdb712a95eba57a5d5992
+  md5: 74683034f513752be1467c9232480a13
+  depends:
+  - __osx >=11.0
+  - libuv >=1.51.0,<2.0a0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT OR Apache-2.0
+  purls:
+  - pkg:pypi/uvloop?source=hash-mapping
+  run_exports: {}
+  size: 492509
+  timestamp: 1762473163613
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-1.2.0-py314he1d1ac0_1.conda
+  sha256: cd8c788feb2a47551b7f37ca7dfa4b5df1fe732007539d29be53874f03c6d945
+  md5: 042bf3289f21e8a5c28551d150704295
+  depends:
+  - python
+  - anyio >=3.0.0
+  - __osx >=11.0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/watchfiles?source=hash-mapping
+  run_exports: {}
+  size: 352931
+  timestamp: 1781180392615
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-16.0-py314ha14b1ff_1.conda
+  sha256: 2d708c6173773cc4883582c216f0ab1e776155aa74116ef6092b7084c879e92b
+  md5: 0cd5ebc7e220c79c6969ec15e82c741e
+  depends:
+  - python
+  - python 3.14.* *_cp314
+  - __osx >=11.0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/websockets?source=hash-mapping
+  run_exports: {}
+  size: 387183
+  timestamp: 1768087446876
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+  sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
+  md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - yaml >=0.2.5,<0.3.0a0
+  size: 83386
+  timestamp: 1753484079473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
+  sha256: 8dd2ac25f0ba714263aac5832d46985648f4bfb9b305b5021d702079badc08d2
+  md5: f1c0bce276210bed45a04949cfe8dc20
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.2 h8088a28_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 81123
+  timestamp: 1774072974535
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+  sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
+  md5: ab136e4c34e97f34fb621d2592a393d8
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 433413
+  timestamp: 1764777166076

--- a/pixi_rare_sort_fastapi/pixi.toml
+++ b/pixi_rare_sort_fastapi/pixi.toml
@@ -1,0 +1,19 @@
+[workspace]
+authors = ["wyzBelinda <27798812+wyzBelinda@users.noreply.github.com>"]
+channels = ["conda-forge"]
+name = "pixi_rare_sort_fastapi"
+platforms = ["osx-arm64"]
+version = "0.1.0"
+
+[tasks]
+start = "uvicorn main:app --host 0.0.0.0 --port 5000 --reload"
+
+[dependencies]
+python = ">=3.11"
+fastapi = ">=0.138.0,<0.139"
+uvicorn = ">=0.49.0,<0.50"
+duckdb = ">=1.5.4,<2"
+pyarrow = ">=24.0.0,<25"
+pandas = ">=3.0.3,<4"
+numpy = ">=2.5.0,<3"
+python-multipart = ">=0.0.32,<0.0.33"


### PR DESCRIPTION
## Summary
5004 版本：列裁剪排除上游  和 ，用我们计算的新值直接覆盖原列名，不再加  后缀。

## Changes
- pipeline.py:  过滤掉上游 /，SQL 输出使用原始列名
- 含 6 个 contributor 的 evidence_summary 证据链 + gene_boost/ppi_boost 因子
- _core.py: registry 重排序（clinvar 移第 5 位）

## Test
- 5004 端口已部署，gene_score + ppi_score 评分正常通过