### PR TITLE
fix(pipeline): phasing 后合并 X/Y/MT，默认 auto 选择 Beagle 染色体

### DIFF
--- a/modules/pipeline/complete_pipeline/full_pipeline_api.py
+++ b/modules/pipeline/complete_pipeline/full_pipeline_api.py
@@ -64,7 +64,10 @@ class RunRequest(BaseModel):
     )
 
     sample_id: Optional[str] = Field(None, description="Advanced override: Sample ID, or auto")
-    chromosomes: Optional[str] = Field(None, description="Advanced override: Chromosome spec, e.g. 22, 1-22, 1,3,5")
+    chromosomes: Optional[str] = Field(
+        None,
+        description="Advanced override: chromosomes processed by Beagle. Default auto phases every patient contig with a reference panel; X/Y/MT and other unsupported contigs are preserved for VEP",
+    )
     ref_dir: Optional[str] = Field(None, description="Advanced override: CHN reference panel directory")
     beagle_jar: Optional[str] = Field(None, description="Advanced override: Beagle jar path")
     ccre_bed: Optional[str] = Field(None, description="Advanced override: cCRE BED.GZ")
@@ -221,7 +224,7 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(
     title="OpenRare V3 Queued Pipeline API",
-    version="0.4.0",
+    version="0.4.1",
     lifespan=lifespan,
 )
 
@@ -379,7 +382,8 @@ def health() -> dict:
         },
         "script_defaults": {
             "sample_id": "auto",
-            "chromosomes": "1-22",
+            "chromosomes": "auto",
+            "chromosomes_scope": "Default auto: Beagle runs on every patient contig with a reference panel; X/Y/MT and other unsupported contigs are preserved unchanged for VEP",
             "ref_dir": str(DEFAULT_REF_DIR),
             "beagle_jar": str(DEFAULT_BEAGLE_JAR),
             "java_bin": DEFAULT_JAVA_BIN,

--- a/modules/pipeline/modules/phasing_beagle_refsupport/scripts/merge_beagle_with_ref_support.py
+++ b/modules/pipeline/modules/phasing_beagle_refsupport/scripts/merge_beagle_with_ref_support.py
@@ -8,7 +8,7 @@ from collections import Counter
 
 INFO_HEADERS = (
     '##INFO=<ID=BEAGLE_PHASED,Number=1,Type=Integer,Description="1 if GT was replaced by Beagle noimpute phased GT; 0 if original GT was retained">\n',
-    '##INFO=<ID=CHN_REF_SUPPORT,Number=1,Type=String,Description="Support category in the supplied reference panel: POLYMORPHIC, MONOMORPHIC_REF, ALLELE_MISMATCH, NOT_IN_REF">\n',
+    '##INFO=<ID=CHN_REF_SUPPORT,Number=1,Type=String,Description="Support category in the supplied reference panel: POLYMORPHIC, MONOMORPHIC_REF, ALLELE_MISMATCH, NOT_IN_REF, NOT_EVALUATED">\n',
     '##INFO=<ID=CHN_ALT_CARRIER_COUNT,Number=1,Type=Integer,Description="Number of reference samples carrying allele 1 at an exactly matched CHROM/POS/REF/ALT marker">\n',
     '##INFO=<ID=CHN_ALT_AC,Number=1,Type=Integer,Description="Allele 1 count in reference samples at an exactly matched CHROM/POS/REF/ALT marker">\n',
     '##INFO=<ID=PHASING_CONFIDENCE,Number=1,Type=String,Description="Confidence label based on Beagle output and reference ALT support: HIGH, LOW, UNPHASED">\n',

--- a/modules/pipeline/modules/phasing_beagle_refsupport/scripts/restore_unphased_variants.sh
+++ b/modules/pipeline/modules/phasing_beagle_refsupport/scripts/restore_unphased_variants.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  restore_unphased_variants.sh --original-vcf FILE --phased-vcf FILE \
+    --output-vcf FILE --ensure-headers-script FILE [--stats FILE]
+
+Merge records phased on selected chromosomes with every original record that was
+not phased. Passthrough records keep their original GT and receive explicit
+phasing/ref-support INFO values.
+EOF
+}
+
+ORIGINAL_VCF=""
+PHASED_VCF=""
+OUTPUT_VCF=""
+ENSURE_HEADERS_SCRIPT=""
+STATS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --original-vcf) ORIGINAL_VCF="${2:?}"; shift 2 ;;
+    --phased-vcf) PHASED_VCF="${2:?}"; shift 2 ;;
+    --output-vcf) OUTPUT_VCF="${2:?}"; shift 2 ;;
+    --ensure-headers-script) ENSURE_HEADERS_SCRIPT="${2:?}"; shift 2 ;;
+    --stats) STATS="${2:?}"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+for value in ORIGINAL_VCF PHASED_VCF OUTPUT_VCF ENSURE_HEADERS_SCRIPT; do
+  [[ -n "${!value}" ]] || { echo "ERROR: --${value,,} is required" >&2; exit 2; }
+done
+[[ -s "$ORIGINAL_VCF" ]] || { echo "ERROR: original VCF not found: $ORIGINAL_VCF" >&2; exit 1; }
+[[ -s "$PHASED_VCF" ]] || { echo "ERROR: phased VCF not found: $PHASED_VCF" >&2; exit 1; }
+[[ -s "$ENSURE_HEADERS_SCRIPT" ]] || { echo "ERROR: header helper not found: $ENSURE_HEADERS_SCRIPT" >&2; exit 1; }
+command -v bcftools >/dev/null 2>&1 || { echo "ERROR: bcftools is required" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 is required" >&2; exit 1; }
+
+mkdir -p "$(dirname "$OUTPUT_VCF")"
+workdir=$(mktemp -d "$(dirname "$OUTPUT_VCF")/.restore_unphased.XXXXXX")
+trap 'rm -rf "$workdir"' EXIT
+
+index_vcf() {
+  local vcf="$1"
+  if [[ ! -s "${vcf}.tbi" && ! -s "${vcf}.csi" ]]; then
+    bcftools index -f -t "$vcf" || bcftools index -f -c "$vcf"
+  fi
+}
+
+index_vcf "$ORIGINAL_VCF"
+index_vcf "$PHASED_VCF"
+
+passthrough_raw="$workdir/passthrough.raw.vcf.gz"
+passthrough_vcf="$workdir/passthrough.tagged.vcf.gz"
+merged_unsorted="$workdir/merged.unsorted.vcf.gz"
+original_keys="$workdir/original.keys"
+merged_keys="$workdir/merged.keys"
+
+# Exact allele matching is intentional: the phasing module guarantees that
+# selected records retain the original CHROM/POS/REF/ALT representation.
+bcftools isec -c none -C -w1 -Oz -o "$passthrough_raw" "$ORIGINAL_VCF" "$PHASED_VCF"
+bcftools index -f -t "$passthrough_raw" || bcftools index -f -c "$passthrough_raw"
+
+python3 "$ENSURE_HEADERS_SCRIPT" \
+  --input-vcf "$passthrough_raw" \
+  --output-vcf "$passthrough_vcf" \
+  --groups phasing \
+  --phasing-passthrough \
+  --index
+
+original_count=$(bcftools view -H "$ORIGINAL_VCF" | wc -l)
+phased_count=$(bcftools view -H "$PHASED_VCF" | wc -l)
+passthrough_count=$(bcftools view -H "$passthrough_vcf" | wc -l)
+
+rm -f "$OUTPUT_VCF" "${OUTPUT_VCF}.tbi" "${OUTPUT_VCF}.csi"
+if [[ "$passthrough_count" -eq 0 ]]; then
+  bcftools view -Oz -o "$OUTPUT_VCF" "$PHASED_VCF"
+else
+  bcftools concat -a -Oz -o "$merged_unsorted" "$PHASED_VCF" "$passthrough_vcf"
+  bcftools sort -T "$workdir/sort" -Oz -o "$OUTPUT_VCF" "$merged_unsorted"
+fi
+bcftools index -f -t "$OUTPUT_VCF" || bcftools index -f -c "$OUTPUT_VCF"
+merged_count=$(bcftools view -H "$OUTPUT_VCF" | wc -l)
+
+[[ $((phased_count + passthrough_count)) -eq "$original_count" ]] || {
+  echo "ERROR: phased + passthrough record count does not equal original: ${phased_count} + ${passthrough_count} != ${original_count}" >&2
+  exit 1
+}
+[[ "$merged_count" -eq "$original_count" ]] || {
+  echo "ERROR: merged record count differs from original: ${merged_count} != ${original_count}" >&2
+  exit 1
+}
+
+bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\n' "$ORIGINAL_VCF" | LC_ALL=C sort > "$original_keys"
+bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\n' "$OUTPUT_VCF" | LC_ALL=C sort > "$merged_keys"
+cmp -s "$original_keys" "$merged_keys" || {
+  echo "ERROR: merged CPRA multiset differs from original VCF" >&2
+  exit 1
+}
+
+if [[ -z "$STATS" ]]; then
+  STATS="${OUTPUT_VCF%.vcf.gz}.preservation.tsv"
+fi
+mkdir -p "$(dirname "$STATS")"
+{
+  printf 'metric\tvalue\n'
+  printf 'original_records\t%s\n' "$original_count"
+  printf 'phased_records\t%s\n' "$phased_count"
+  printf 'passthrough_records\t%s\n' "$passthrough_count"
+  printf 'merged_records\t%s\n' "$merged_count"
+  printf 'cpra_multiset_match\tyes\n'
+} > "$STATS"
+
+echo "RESTORE_OK original=${original_count} phased=${phased_count} passthrough=${passthrough_count} merged=${merged_count}"
+echo "output_vcf=$OUTPUT_VCF"
+echo "stats=$STATS"

--- a/modules/pipeline/modules/phasing_beagle_refsupport/scripts/run_beagle_refsupport_pipeline.sh
+++ b/modules/pipeline/modules/phasing_beagle_refsupport/scripts/run_beagle_refsupport_pipeline.sh
@@ -16,7 +16,7 @@ Required:
   --ref-dir DIR            Reference VCF directory
   --out-dir DIR            Pipeline output directory
   --beagle-jar FILE        Beagle 5.x jar
-  --chromosomes SPEC       Example: 1-22 or 1,3,5,22
+  --chromosomes SPEC       auto, all, 1-22, or 1,3,5,22 (auto = every patient contig with a reference panel)
 
 Optional:
   --sample-id ID           Default: automatically detect the single VCF sample
@@ -149,13 +149,52 @@ expand_chromosomes() {
         tr ',' '\n' <<<"$1"
     fi
 }
-mapfile -t chroms < <(expand_chromosomes "${CHROMOSOMES}")
-[[ "${#chroms[@]}" -gt 0 ]] || { echo "ERROR: empty chromosome list" >&2; exit 1; }
+
+contig_to_beagle_chr() {
+    local contig="$1"
+    contig="${contig#chr}"
+    contig="${contig#CHR}"
+    if [[ "${contig}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "${contig}"
+        return 0
+    fi
+    return 1
+}
+
+resolve_chromosome_list() {
+    local spec="$1"
+    if [[ "${spec}" == auto || "${spec}" == all ]]; then
+        declare -A seen=()
+        local contig chr ref
+        while IFS= read -r contig; do
+            [[ -n "${contig}" ]] || continue
+            chr=$(contig_to_beagle_chr "${contig}") || continue
+            ref="${REF_DIR}/${REF_PREFIX}.chr${chr}.${REF_SUFFIX}"
+            [[ -s "${ref}" ]] || continue
+            [[ -n "${seen[$chr]:-}" ]] && continue
+            seen["${chr}"]=1
+            printf '%s\n' "${chr}"
+        done < <("${BCFTOOLS_BIN}" query -f '%CHROM\n' "${PATIENT_VCF}" | sort -u) | sort -n
+        return 0
+    fi
+    expand_chromosomes "${spec}"
+}
+
+CHROMOSOMES_SPEC="${CHROMOSOMES}"
+mapfile -t chroms < <(resolve_chromosome_list "${CHROMOSOMES}")
+[[ "${#chroms[@]}" -gt 0 ]] || {
+    echo "ERROR: empty chromosome list (spec=${CHROMOSOMES}; no patient contig matched an available reference panel)" >&2
+    exit 1
+}
+if [[ "${CHROMOSOMES_SPEC}" == auto || "${CHROMOSOMES_SPEC}" == all ]]; then
+    CHROMOSOMES="$(IFS=,; echo "${chroms[*]}")"
+    echo "AUTO_CHROMOSOMES resolved=${CHROMOSOMES}"
+fi
 for chr in "${chroms[@]}"; do
     [[ "${chr}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: invalid chromosome: ${chr}" >&2; exit 2; }
 done
 
-echo "CONFIG sample=${SAMPLE_ID} chromosomes=${CHROMOSOMES} chr_jobs=${CHR_JOBS} beagle_threads=${BEAGLE_THREADS} heap_gb=${JAVA_HEAP_GB} seed_base=${SEED_BASE}"
+echo "CONFIG sample=${SAMPLE_ID} chromosomes_spec=${CHROMOSOMES_SPEC} chromosomes=${CHROMOSOMES} chr_jobs=${CHR_JOBS} beagle_threads=${BEAGLE_THREADS} heap_gb=${JAVA_HEAP_GB} seed_base=${SEED_BASE}"
 for chr in "${chroms[@]}"; do
     ref="${REF_DIR}/${REF_PREFIX}.chr${chr}.${REF_SUFFIX}"
     [[ -s "${ref}" ]] || { echo "ERROR: missing reference: ${ref}" >&2; exit 1; }
@@ -228,7 +267,9 @@ SUMMARY="${OUT_DIR}/logs/allchr_refsupport_summary.tsv"
     done
 } >"${SUMMARY}"
 
-if [[ "${CHROMOSOMES}" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+if [[ "${CHROMOSOMES_SPEC}" == auto || "${CHROMOSOMES_SPEC}" == all ]]; then
+    merged_label="auto"
+elif [[ "${CHROMOSOMES}" =~ ^([0-9]+)-([0-9]+)$ ]]; then
     merged_label="${BASH_REMATCH[1]}_${BASH_REMATCH[2]}"
 else
     merged_label=$(tr ',' '_' <<<"${CHROMOSOMES}")

--- a/modules/pipeline/modules/vcf_preprocessing/scripts/ensure_vcf_info_headers.py
+++ b/modules/pipeline/modules/vcf_preprocessing/scripts/ensure_vcf_info_headers.py
@@ -11,7 +11,7 @@ from pathlib import Path
 HEADERS: dict[str, list[str]] = {
     "phasing": [
         '##INFO=<ID=BEAGLE_PHASED,Number=1,Type=Integer,Description="1 if GT was replaced by Beagle noimpute phased GT; 0 if original GT was retained">',
-        '##INFO=<ID=CHN_REF_SUPPORT,Number=1,Type=String,Description="Support category in the supplied reference panel: POLYMORPHIC, MONOMORPHIC_REF, ALLELE_MISMATCH, NOT_IN_REF">',
+        '##INFO=<ID=CHN_REF_SUPPORT,Number=1,Type=String,Description="Support category in the supplied reference panel: POLYMORPHIC, MONOMORPHIC_REF, ALLELE_MISMATCH, NOT_IN_REF, NOT_EVALUATED">',
         '##INFO=<ID=CHN_ALT_CARRIER_COUNT,Number=1,Type=Integer,Description="Number of reference samples carrying allele 1 at an exactly matched CHROM/POS/REF/ALT marker">',
         '##INFO=<ID=CHN_ALT_AC,Number=1,Type=Integer,Description="Allele 1 count in reference samples at an exactly matched CHROM/POS/REF/ALT marker">',
         '##INFO=<ID=PHASING_CONFIDENCE,Number=1,Type=String,Description="Confidence label based on Beagle output and reference ALT support: HIGH, LOW, UNPHASED">',
@@ -73,9 +73,16 @@ def main() -> None:
     ap.add_argument("--input-vcf", required=True)
     ap.add_argument("--output-vcf", required=True)
     ap.add_argument("--groups", required=True, help="Comma-separated groups: phasing,vaf,regulatory,ncrna,pseudogene")
+    ap.add_argument(
+        "--phasing-passthrough",
+        action="store_true",
+        help="Mark every record as retained without phasing/ref-panel evaluation",
+    )
     ap.add_argument("--index", action="store_true", help="Create tabix index for .gz output")
     args = ap.parse_args()
     groups = [x.strip() for x in args.groups.split(",") if x.strip()]
+    if args.phasing_passthrough and "phasing" not in groups:
+        raise SystemExit("--phasing-passthrough requires the phasing header group")
     wanted: list[str] = []
     for group in groups:
         if group not in HEADERS:
@@ -99,6 +106,23 @@ def main() -> None:
                         if info_id not in existing:
                             writer.write(header + "\n")
                     inserted = True
+                if args.phasing_passthrough and not line.startswith("#"):
+                    fields = line.rstrip("\n").split("\t")
+                    if len(fields) < 8:
+                        raise SystemExit(f"invalid VCF record with {len(fields)} columns: {line[:120]!r}")
+                    info_items = [] if fields[7] in {"", "."} else fields[7].split(";")
+                    info_by_id = {item.split("=", 1)[0]: item for item in info_items}
+                    passthrough_values = {
+                        "BEAGLE_PHASED": "0",
+                        "CHN_REF_SUPPORT": "NOT_EVALUATED",
+                        "CHN_ALT_CARRIER_COUNT": ".",
+                        "CHN_ALT_AC": ".",
+                        "PHASING_CONFIDENCE": "UNPHASED",
+                    }
+                    for info_id, value in passthrough_values.items():
+                        info_by_id[info_id] = f"{info_id}={value}"
+                    fields[7] = ";".join(info_by_id.values()) or "."
+                    line = "\t".join(fields) + "\n"
                 writer.write(line)
     finally:
         close_writer(writer, proc, raw)

--- a/modules/pipeline/pixi.toml
+++ b/modules/pipeline/pixi.toml
@@ -44,5 +44,6 @@ api = { cmd = [
 api-test = { cmd = ["bash", "test/run_api_integration_test.sh"] }
 mock-smoke-test = { cmd = ["bash", "test/run_mock_smoke_dryrun.sh"] }
 hla-filter-test = { cmd = ["bash", "test/run_hla_filter_unit.sh"] }
+xy-mt-preservation-test = { cmd = ["bash", "test/run_xy_mt_preservation_test.sh"] }
 vep-setup-plugins = { cmd = ["bash", "modules/vep_runner/scripts/install_vep_plugins.sh"] }
 vep-verify-plugins = { cmd = ["bash", "modules/vep_runner/scripts/verify_vep_plugins.sh"] }

--- a/modules/pipeline/scripts/run_full_pipeline.sh
+++ b/modules/pipeline/scripts/run_full_pipeline.sh
@@ -6,6 +6,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT}/config/paths.sh"
 
 PHASING_SCRIPT="${ROOT}/modules/phasing_beagle_refsupport/scripts/run_beagle_refsupport_pipeline.sh"
+RESTORE_UNPHASED_SCRIPT="${ROOT}/modules/phasing_beagle_refsupport/scripts/restore_unphased_variants.sh"
 PREPROCESS_SCRIPT="${ROOT}/modules/vcf_preprocessing/run_vcf_preprocessing.sh"
 LIFTOVER_PY="${OPENRARE_LIFTOVER_SCRIPT}"
 PSEUDOGENE_PY="${ROOT}/modules/pseudogene_annotation/scripts/annotate_pseudogene.py"
@@ -38,7 +39,7 @@ Common optional:
 
 Advanced optional overrides, usually not needed:
   --sample-id ID            Sample ID used for output prefixes; default: auto
-  --chromosomes SPEC        Default: 1-22. Example: 22, 1-22, or 1,3,5
+  --chromosomes SPEC        Beagle target chromosomes, default: auto (all patient contigs with a reference panel). Other contigs (X/Y/MT included) are preserved unchanged
   --ref-dir DIR             CHN reference panel directory for Beagle phasing
   --beagle-jar FILE         Beagle jar path
   --ccre-bed FILE           cCRE slim BED.GZ
@@ -61,7 +62,7 @@ OUT_DIR=""
 SAMPLE_ID="auto"
 REF_DIR="${FULL_PIPELINE_REF_DIR}"
 BEAGLE_JAR="${FULL_PIPELINE_BEAGLE_JAR}"
-CHROMOSOMES="1-22"
+CHROMOSOMES="auto"
 JAVA_BIN="${JAVA_BIN:-java}"
 CCRE_BED="${ROOT}/modules/vcf_preprocessing/resources/regulatory/hg38/encode_screen_v4_grch38_ccre.slim.bed.gz"
 NCRNA_BED="${ROOT}/modules/vcf_preprocessing/resources/ncrna/hg38/gencode.v49.ncrna_gene.slim.bed.gz"
@@ -152,6 +153,7 @@ fi
 [[ -s "$PSEUDOGENE_PY" ]] || { echo "ERROR: pseudogene script not found: $PSEUDOGENE_PY" >&2; exit 1; }
 [[ -s "$INFO_TO_CSV_SCRIPT" ]] || { echo "ERROR: INFO-to-CSV script not found: $INFO_TO_CSV_SCRIPT" >&2; exit 1; }
 [[ -s "$ENSURE_HEADERS_SCRIPT" ]] || { echo "ERROR: ensure-header script not found: $ENSURE_HEADERS_SCRIPT" >&2; exit 1; }
+[[ -x "$RESTORE_UNPHASED_SCRIPT" ]] || { echo "ERROR: unphased-variant restore script not found or not executable: $RESTORE_UNPHASED_SCRIPT" >&2; exit 1; }
 [[ -s "$GENOS_EVEE_SCRIPT" ]] || { echo "ERROR: GENOS-VarRisk annotation script not found: $GENOS_EVEE_SCRIPT" >&2; exit 1; }
 [[ -s "$HLA_FILTER_SCRIPT" ]] || { echo "ERROR: HLA filter script not found: $HLA_FILTER_SCRIPT" >&2; exit 1; }
 case "$INPUT_ASSEMBLY" in
@@ -271,6 +273,8 @@ if [[ "$SAMPLE_ID" != auto ]]; then
 fi
 
 phased_vcf=""
+phased_selected_vcf=""
+phasing_preservation_stats="${OUT_DIR}/01_phasing/all_contigs.preservation.tsv"
 if [[ "$PHASING" == yes ]]; then
   run_cmd bash "$PHASING_SCRIPT" \
     --patient-vcf "$PIPELINE_INPUT_VCF" \
@@ -286,12 +290,19 @@ if [[ "$PHASING" == yes ]]; then
     --resume yes
 
   if [[ "$DRY_RUN" == yes ]]; then
-    phased_vcf="${OUT_DIR}/01_phasing/<sample>.chr<chromosomes>.original_sites.beagle_phase_merged.refsupport.vcf.gz"
+    phased_selected_vcf="${OUT_DIR}/01_phasing/<sample>.chr<chromosomes>.original_sites.beagle_phase_merged.refsupport.vcf.gz"
   else
     mapfile -t phased_candidates < <(find "${OUT_DIR}/01_phasing" -maxdepth 1 -type f -name '*.original_sites.beagle_phase_merged.refsupport.vcf.gz' | sort)
     [[ "${#phased_candidates[@]}" -eq 1 ]] || { echo "ERROR: expected one phased VCF, found ${#phased_candidates[@]}" >&2; exit 1; }
-    phased_vcf="${phased_candidates[0]}"
+    phased_selected_vcf="${phased_candidates[0]}"
   fi
+  phased_vcf="${OUT_DIR}/01_phasing/input.all_contigs.phased_and_passthrough.vcf.gz"
+  run_cmd bash "$RESTORE_UNPHASED_SCRIPT" \
+    --original-vcf "$PIPELINE_INPUT_VCF" \
+    --phased-vcf "$phased_selected_vcf" \
+    --output-vcf "$phased_vcf" \
+    --ensure-headers-script "$ENSURE_HEADERS_SCRIPT" \
+    --stats "$phasing_preservation_stats"
 else
   phased_vcf="${OUT_DIR}/01_phasing/input.with_phasing_headers.vcf.gz"
   printf '[%s] SKIP phasing: adding expected phasing INFO headers only: %s\n' "$(date '+%F %T')" "$phased_vcf"
@@ -409,6 +420,9 @@ fi
   printf 'pseudogene_annotation\t%s\n' "$PSEUDOGENE_ANNOTATION"
   printf 'hla_filter\t%s\n' "$HLA_FILTER"
   printf 'phased_vcf\t%s\n' "$phased_vcf"
+  printf 'phased_selected_vcf\t%s\n' "$phased_selected_vcf"
+  printf 'phasing_chromosomes\t%s\n' "$CHROMOSOMES"
+  printf 'phasing_preservation_stats\t%s\n' "$phasing_preservation_stats"
   printf 'preprocessed_vcf\t%s\n' "$preprocessed_vcf"
   printf 'pseudogene_annotated_vcf\t%s\n' "$pseudo_vcf"
   printf 'vep_base_csv\t%s\n' "$vep_base_csv"

--- a/modules/pipeline/test/run_xy_mt_preservation_test.sh
+++ b/modules/pipeline/test/run_xy_mt_preservation_test.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Unit tests: restore_unphased_variants.sh must preserve chrX/chrY when not in --chromosomes.
+set -euo pipefail
+
+PIPELINE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESTORE_SCRIPT="${PIPELINE_ROOT}/modules/phasing_beagle_refsupport/scripts/restore_unphased_variants.sh"
+ENSURE_HEADERS="${PIPELINE_ROOT}/modules/vcf_preprocessing/scripts/ensure_vcf_info_headers.py"
+OUT_DIR="${OPENRARE_XY_MT_TEST_OUT:-${PIPELINE_ROOT}/tmp/xy_mt_preservation_test}"
+mkdir -p "$OUT_DIR"
+
+chmod +x "$RESTORE_SCRIPT"
+
+PHASING_INFO='##INFO=<ID=BEAGLE_PHASED,Number=1,Type=Integer,Description="Beagle phased">
+##INFO=<ID=CHN_REF_SUPPORT,Number=1,Type=String,Description="Ref support">
+##INFO=<ID=CHN_ALT_CARRIER_COUNT,Number=1,Type=Integer,Description="Carrier count">
+##INFO=<ID=CHN_ALT_AC,Number=1,Type=Integer,Description="AC">
+##INFO=<ID=PHASING_CONFIDENCE,Number=1,Type=String,Description="Confidence">'
+
+run_case() {
+  local name="$1"
+  local original_vcf="$2"
+  local phased_vcf="$3"
+  local merged_vcf="$4"
+  local stats="$5"
+  local expected_original="$6"
+  local expected_phased="$7"
+  local expected_passthrough="$8"
+
+  printf '\n[case:%s] running restore...\n' "$name"
+  bgzip -f -c "$original_vcf" > "${original_vcf}.gz"
+  bcftools index -f -t "${original_vcf}.gz"
+  bgzip -f -c "$phased_vcf" > "${phased_vcf}.gz"
+  bcftools index -f -t "${phased_vcf}.gz"
+
+  bash "$RESTORE_SCRIPT" \
+    --original-vcf "${original_vcf}.gz" \
+    --phased-vcf "${phased_vcf}.gz" \
+    --output-vcf "$merged_vcf" \
+    --ensure-headers-script "$ENSURE_HEADERS" \
+    --stats "$stats"
+
+  grep -q $'original_records\t'"${expected_original}" "$stats" || {
+    echo "ERROR [$name]: expected original_records=${expected_original}" >&2; exit 1; }
+  grep -q $'phased_records\t'"${expected_phased}" "$stats" || {
+    echo "ERROR [$name]: expected phased_records=${expected_phased}" >&2; exit 1; }
+  grep -q $'passthrough_records\t'"${expected_passthrough}" "$stats" || {
+    echo "ERROR [$name]: expected passthrough_records=${expected_passthrough}" >&2; exit 1; }
+  grep -q $'merged_records\t'"${expected_original}" "$stats" || {
+    echo "ERROR [$name]: expected merged_records=${expected_original}" >&2; exit 1; }
+  grep -q $'cpra_multiset_match\tyes' "$stats" || {
+    echo "ERROR [$name]: expected cpra_multiset_match=yes" >&2; exit 1; }
+
+  printf '[case:%s] stats:\n' "$name"
+  cat "$stats"
+}
+
+assert_passthrough() {
+  local name="$1"
+  local merged_vcf="$2"
+  local chrom="$3"
+  local pos="$4"
+  local expected_gt="$5"
+
+  local line
+  line="$(bcftools view -H "$merged_vcf" "${chrom}:${pos}-${pos}")"
+  [[ -n "$line" ]] || { echo "ERROR [$name]: ${chrom}:${pos} missing" >&2; exit 1; }
+  echo "$line" | grep -q 'CHN_REF_SUPPORT=NOT_EVALUATED' || {
+    echo "ERROR [$name]: ${chrom}:${pos} should have CHN_REF_SUPPORT=NOT_EVALUATED" >&2; exit 1; }
+  echo "$line" | grep -q 'BEAGLE_PHASED=0' || {
+    echo "ERROR [$name]: ${chrom}:${pos} should have BEAGLE_PHASED=0" >&2; exit 1; }
+  echo "$line" | grep -q "GT[[:space:]]${expected_gt}" || {
+    echo "ERROR [$name]: ${chrom}:${pos} GT should remain ${expected_gt}, got: $line" >&2; exit 1; }
+}
+
+assert_phased() {
+  local name="$1"
+  local merged_vcf="$2"
+  local chrom="$3"
+  local pos="$4"
+  local expected_gt="$5"
+
+  local line
+  line="$(bcftools view -H "$merged_vcf" "${chrom}:${pos}-${pos}")"
+  [[ -n "$line" ]] || { echo "ERROR [$name]: ${chrom}:${pos} missing" >&2; exit 1; }
+  echo "$line" | grep -q 'BEAGLE_PHASED=1' || {
+    echo "ERROR [$name]: ${chrom}:${pos} should have BEAGLE_PHASED=1" >&2; exit 1; }
+  echo "$line" | grep -q "GT[[:space:]]${expected_gt}" || {
+    echo "ERROR [$name]: ${chrom}:${pos} phased GT should be ${expected_gt}, got: $line" >&2; exit 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: --chromosomes 1  (default 1-22 behaviour) — chrX/chrY are passthrough
+# ---------------------------------------------------------------------------
+CASE1_DIR="${OUT_DIR}/case1_chr1_phased"
+mkdir -p "$CASE1_DIR"
+
+cat >"${CASE1_DIR}/original.vcf" <<'EOF'
+##fileformat=VCFv4.2
+##contig=<ID=chr1,length=248956422>
+##contig=<ID=chrX,length=156040895>
+##contig=<ID=chrY,length=57227415>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+chr1	100	.	A	G	50	PASS	.	GT	0/1
+chrX	2786989	.	C	T	50	PASS	.	GT	0/1
+chrX	154931044	.	G	A	50	PASS	.	GT	1/1
+chrY	2667398	.	A	G	50	PASS	.	GT	0/1
+chrY	2781479	.	T	C	50	PASS	.	GT	1
+EOF
+
+cat >"${CASE1_DIR}/phased.vcf" <<EOF
+##fileformat=VCFv4.2
+##contig=<ID=chr1,length=248956422>
+${PHASING_INFO}
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+chr1	100	.	A	G	50	PASS	BEAGLE_PHASED=1;CHN_REF_SUPPORT=POLYMORPHIC;CHN_ALT_CARRIER_COUNT=10;CHN_ALT_AC=12;PHASING_CONFIDENCE=HIGH	GT	0|1
+EOF
+
+run_case "chr1_phased_xy_passthrough" \
+  "${CASE1_DIR}/original.vcf" \
+  "${CASE1_DIR}/phased.vcf" \
+  "${CASE1_DIR}/merged.vcf.gz" \
+  "${CASE1_DIR}/preservation.tsv" \
+  5 1 4
+
+assert_phased "chr1_phased_xy_passthrough" "${CASE1_DIR}/merged.vcf.gz" chr1 100 "0|1"
+assert_passthrough "chr1_phased_xy_passthrough" "${CASE1_DIR}/merged.vcf.gz" chrX 2786989 "0/1"
+assert_passthrough "chr1_phased_xy_passthrough" "${CASE1_DIR}/merged.vcf.gz" chrX 154931044 "1/1"
+assert_passthrough "chr1_phased_xy_passthrough" "${CASE1_DIR}/merged.vcf.gz" chrY 2781479 "1"
+assert_passthrough "chr1_phased_xy_passthrough" "${CASE1_DIR}/merged.vcf.gz" chrY 2667398 "0/1"
+
+xy_count=$(bcftools view -H "${CASE1_DIR}/merged.vcf.gz" chrX | wc -l)
+yy_count=$(bcftools view -H "${CASE1_DIR}/merged.vcf.gz" chrY | wc -l)
+[[ "$xy_count" -eq 2 ]] || { echo "ERROR: expected 2 chrX records, got $xy_count" >&2; exit 1; }
+[[ "$yy_count" -eq 2 ]] || { echo "ERROR: expected 2 chrY records, got $yy_count" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Case 2: --chromosomes X — only chrX phased, chrY passthrough
+# ---------------------------------------------------------------------------
+CASE2_DIR="${OUT_DIR}/case2_chrx_phased"
+mkdir -p "$CASE2_DIR"
+
+cat >"${CASE2_DIR}/original.vcf" <<'EOF'
+##fileformat=VCFv4.2
+##contig=<ID=chrX,length=156040895>
+##contig=<ID=chrY,length=57227415>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+chrX	2786989	.	C	T	50	PASS	.	GT	0/1
+chrX	154931044	.	G	A	50	PASS	.	GT	0/0
+chrY	2667398	.	A	G	50	PASS	.	GT	0/1
+chrY	2781479	.	T	C	50	PASS	.	GT	1
+EOF
+
+cat >"${CASE2_DIR}/phased.vcf" <<EOF
+##fileformat=VCFv4.2
+##contig=<ID=chrX,length=156040895>
+${PHASING_INFO}
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+chrX	2786989	.	C	T	50	PASS	BEAGLE_PHASED=1;CHN_REF_SUPPORT=POLYMORPHIC;CHN_ALT_CARRIER_COUNT=5;CHN_ALT_AC=6;PHASING_CONFIDENCE=HIGH	GT	0|1
+chrX	154931044	.	G	A	50	PASS	BEAGLE_PHASED=1;CHN_REF_SUPPORT=MONOMORPHIC_REF;CHN_ALT_CARRIER_COUNT=0;CHN_ALT_AC=0;PHASING_CONFIDENCE=LOW	GT	0|0
+EOF
+
+run_case "chrx_phased_y_passthrough" \
+  "${CASE2_DIR}/original.vcf" \
+  "${CASE2_DIR}/phased.vcf" \
+  "${CASE2_DIR}/merged.vcf.gz" \
+  "${CASE2_DIR}/preservation.tsv" \
+  4 2 2
+
+assert_phased "chrx_phased_y_passthrough" "${CASE2_DIR}/merged.vcf.gz" chrX 2786989 "0|1"
+assert_phased "chrx_phased_y_passthrough" "${CASE2_DIR}/merged.vcf.gz" chrX 154931044 "0|0"
+assert_passthrough "chrx_phased_y_passthrough" "${CASE2_DIR}/merged.vcf.gz" chrY 2781479 "1"
+assert_passthrough "chrx_phased_y_passthrough" "${CASE2_DIR}/merged.vcf.gz" chrY 2667398 "0/1"
+
+# ---------------------------------------------------------------------------
+# Case 3: --chromosomes Y — only chrY phased, chrX passthrough
+# ---------------------------------------------------------------------------
+CASE3_DIR="${OUT_DIR}/case3_chry_phased"
+mkdir -p "$CASE3_DIR"
+
+cat >"${CASE3_DIR}/original.vcf" <<'EOF'
+##fileformat=VCFv4.2
+##contig=<ID=chrX,length=156040895>
+##contig=<ID=chrY,length=57227415>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+chrX	2786989	.	C	T	50	PASS	.	GT	0/1
+chrY	2667398	.	A	G	50	PASS	.	GT	0/1
+chrY	2781479	.	T	C	50	PASS	.	GT	1
+EOF
+
+cat >"${CASE3_DIR}/phased.vcf" <<EOF
+##fileformat=VCFv4.2
+##contig=<ID=chrY,length=57227415>
+${PHASING_INFO}
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+chrY	2667398	.	A	G	50	PASS	BEAGLE_PHASED=1;CHN_REF_SUPPORT=POLYMORPHIC;CHN_ALT_CARRIER_COUNT=2;CHN_ALT_AC=2;PHASING_CONFIDENCE=HIGH	GT	0|1
+chrY	2781479	.	T	C	50	PASS	BEAGLE_PHASED=1;CHN_REF_SUPPORT=POLYMORPHIC;CHN_ALT_CARRIER_COUNT=3;CHN_ALT_AC=4;PHASING_CONFIDENCE=HIGH	GT	1
+EOF
+
+run_case "chry_phased_x_passthrough" \
+  "${CASE3_DIR}/original.vcf" \
+  "${CASE3_DIR}/phased.vcf" \
+  "${CASE3_DIR}/merged.vcf.gz" \
+  "${CASE3_DIR}/preservation.tsv" \
+  3 2 1
+
+assert_passthrough "chry_phased_x_passthrough" "${CASE3_DIR}/merged.vcf.gz" chrX 2786989 "0/1"
+assert_phased "chry_phased_x_passthrough" "${CASE3_DIR}/merged.vcf.gz" chrY 2781479 "1"
+assert_phased "chry_phased_x_passthrough" "${CASE3_DIR}/merged.vcf.gz" chrY 2667398 "0|1"
+
+# ---------------------------------------------------------------------------
+# Case 4: contig naming without "chr" prefix (X/Y) — passthrough when phasing 1-22
+# ---------------------------------------------------------------------------
+CASE4_DIR="${OUT_DIR}/case4_no_chr_prefix"
+mkdir -p "$CASE4_DIR"
+
+cat >"${CASE4_DIR}/original.vcf" <<'EOF'
+##fileformat=VCFv4.2
+##contig=<ID=1,length=248956422>
+##contig=<ID=X,length=156040895>
+##contig=<ID=Y,length=57227415>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+1	100	.	A	G	50	PASS	.	GT	0/1
+X	200	.	C	T	50	PASS	.	GT	0/1
+Y	300	.	G	A	50	PASS	.	GT	1
+EOF
+
+cat >"${CASE4_DIR}/phased.vcf" <<EOF
+##fileformat=VCFv4.2
+##contig=<ID=1,length=248956422>
+${PHASING_INFO}
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE
+1	100	.	A	G	50	PASS	BEAGLE_PHASED=1;CHN_REF_SUPPORT=POLYMORPHIC;CHN_ALT_CARRIER_COUNT=10;CHN_ALT_AC=12;PHASING_CONFIDENCE=HIGH	GT	0|1
+EOF
+
+run_case "no_chr_prefix_xy_passthrough" \
+  "${CASE4_DIR}/original.vcf" \
+  "${CASE4_DIR}/phased.vcf" \
+  "${CASE4_DIR}/merged.vcf.gz" \
+  "${CASE4_DIR}/preservation.tsv" \
+  3 1 2
+
+assert_passthrough "no_chr_prefix_xy_passthrough" "${CASE4_DIR}/merged.vcf.gz" X 200 "0/1"
+assert_passthrough "no_chr_prefix_xy_passthrough" "${CASE4_DIR}/merged.vcf.gz" Y 300 "1"
+
+printf '\n[xy-mt-preservation-test] ALL CASES OK\n'
+printf '  case1 (chr1 phased, chrX/chrY passthrough): %s\n' "${CASE1_DIR}/merged.vcf.gz"
+printf '  case2 (chrX phased, chrY passthrough):       %s\n' "${CASE2_DIR}/merged.vcf.gz"
+printf '  case3 (chrY phased, chrX passthrough):       %s\n' "${CASE3_DIR}/merged.vcf.gz"
+printf '  case4 (X/Y without chr prefix, passthrough):  %s\n' "${CASE4_DIR}/merged.vcf.gz"


### PR DESCRIPTION
Beagle 默认只处理部分常染色体时，旧流程会把未 phasing 的 contig 从 VCF 中 截掉，导致 X/Y/MT 无法进入 VEP。新增 restore_unphased_variants.sh，在 phasing 后将旁路位点按 CPRA 合并回全 contig VCF，并为旁路记录写入 NOT_EVALUATED 等 INFO；CLI/API 默认 chromosomes 改为 auto（对 VCF 中有参考 panel 的 contig 做 Beagle），并补充 chrX/chrY 保留单元测试。
@wangz1lu 