### PR TITLE
新增标准染色体过滤步骤，过滤非标准 contig 后再进入下游流程

### DIFF
--- a/modules/pipeline/EXTERNAL_PATHS.md
+++ b/modules/pipeline/EXTERNAL_PATHS.md
@@ -52,6 +52,7 @@ cp .env.example .env
 | `scripts/run_full_pipeline.sh` | 全流程 CLI 入口 |
 | `scripts/start_full_pipeline_api.sh` | API 启动脚本 |
 | `modules/vcf_preprocessing/liftover_grch37/scripts/run_liftover_vcf.py` | GRCh37→GRCh38 liftover |
+| `modules/liftover/scripts/filter_standard_chromosomes_vcf.py` | 标准染色体过滤 |
 | `complete_pipeline/full_pipeline_api.py` | FastAPI 服务 |
 | `modules/vep_runner/config/vep_runner_config.json` | VEP 配置（`${OPENRARE_DATA_ROOT}` 占位符） |
 | `modules/vcf_preprocessing/resources/regulatory/hg38/encode_screen_v4_grch38_ccre.slim.bed.gz` | cCRE BED |
@@ -67,6 +68,8 @@ cp .env.example .env
 |------|----------|------|
 | 输入 | `00_input/<basename>.vcf.gz` | 规范化后的输入 |
 | 00b | `00_liftover/output/output.grch38.norm.vcf.gz` | GRCh37 输入经 liftover 后的 GRCh38 VCF（可选） |
+| 00c | `00_liftover_filter/input.standard_chromosomes.vcf.gz` | 标准染色体过滤后的 VCF（默认开启） |
+| 00c | `00_liftover_filter/input.ignored_nonstandard_chromosomes.tsv` | 被过滤的非标准 contig 变异 |
 | 01 | `01_phasing/*.original_sites.beagle_phase_merged.refsupport.vcf.gz` | Phasing 结果 |
 | 02 | `02_vcf_preprocessing/preprocessed.regulatory.vcf.gz` | VAF + cCRE + ncRNA |
 | 03 | `03_pseudogene_annotation/preprocessed.pseudogene_annotated.vcf.gz` | 假基因注释（进 VEP） |

--- a/modules/pipeline/README.md
+++ b/modules/pipeline/README.md
@@ -289,8 +289,9 @@ pixi run mock-smoke-test
 | `--ncrna-annotation yes\|no` | 否 | `yes` | 是否运行 ncRNA 注释 |
 | `--pseudogene-annotation yes\|no` | 否 | `yes` | 是否运行假基因注释 |
 | `--hla-filter yes\|no` | 否 | `yes` | 是否删除 HLA/MHC 区行 |
+| `--liftover-filter-standard-chroms yes\|no` | 否 | `yes` | 是否仅保留标准染色体（1-22,X,Y,MT）；非标准 contig 写入 `00_liftover_filter/` |
 | `--sample-id ID` | 否 | `auto` | 样本名 |
-| `--chromosomes SPEC` | 否 | `1-22` | 如 `1`、`1,3,5` |
+| `--chromosomes SPEC` | 否 | `auto` | Beagle 目标染色体；有参考 panel 的 contig 自动 phase |
 | `--ref-dir DIR` | 否 | `$FULL_PIPELINE_REF_DIR` | Beagle 参考 panel |
 | `--beagle-jar FILE` | 否 | `$FULL_PIPELINE_BEAGLE_JAR` | Beagle JAR |
 | `--java-bin PATH` | 否 | `$JAVA_BIN` | Java 可执行文件 |
@@ -310,6 +311,7 @@ pixi run bash scripts/run_full_pipeline.sh --help
 |------|------|------|--------|
 | 00 | `00_input/` | 输入 VCF 规范化（bgzip + 索引） | `*.vcf.gz` |
 | 00b | `00_liftover/` | GRCh37→GRCh38 liftover（`--input-assembly` 触发） | `output.grch38.norm.vcf.gz` |
+| 00c | `00_liftover_filter/` | 标准染色体过滤（`--liftover-filter-standard-chroms`，默认开启） | `input.standard_chromosomes.vcf.gz` |
 | 01 | `01_phasing/` | Beagle + CHN 参考 phasing/ref-support（可 `--phasing no` 跳过） | `*.refsupport.vcf.gz` |
 | 02 | `02_vcf_preprocessing/` | VAF、cCRE、ncRNA 注释（各步可 `no` 跳过） | `preprocessed.regulatory.vcf.gz` |
 | 03 | `03_pseudogene_annotation/` | 假基因 INFO 注释（可跳过） | `preprocessed.pseudogene_annotated.vcf.gz` |
@@ -338,6 +340,8 @@ pixi run bash scripts/run_full_pipeline.sh --help
 |------|------|
 | `<out-dir>/04_vep/vep_output.base.csv` | VEP 基础 CSV |
 | `<out-dir>/04_vep/raw_vep.tsv` | VEP 原始 TSV（默认保留） |
+| `<out-dir>/00_liftover_filter/input.standard_chromosomes.vcf.gz` | 标准染色体过滤后的 VCF |
+| `<out-dir>/00_liftover_filter/input.ignored_nonstandard_chromosomes.tsv` | 被过滤的非标准 contig 变异 |
 | `<out-dir>/06_genos_evee_annotation/vep_output.with_genos_evee.csv` | GENOS-VarRisk 宽表（HLA 过滤前） |
 | `<out-dir>/07_hla_filter/vep_output.no_hla.csv` | **最终宽表**（默认） |
 | `<out-dir>/full_pipeline.outputs.tsv` | 各步产物路径索引 |
@@ -368,6 +372,7 @@ modules/pipeline/                    # 本模块（pixi 项目根）
 │   └── api_jobs/                    # API 任务目录（gitignore）
 ├── modules/                         # 各步骤实现
 │   ├── phasing_beagle_refsupport/
+│   ├── liftover/                    # 标准染色体过滤（00_liftover_filter）
 │   ├── vcf_preprocessing/
 │   ├── pseudogene_annotation/
 │   ├── vep_runner/
@@ -406,6 +411,7 @@ VEP 配置 [`modules/vep_runner/config/vep_runner_config.json`](modules/vep_runn
 | 文档 | 内容 |
 |------|------|
 | [complete_pipeline/README.md](complete_pipeline/README.md) | API 与 CLI 详细参数 |
+| [modules/liftover/README.md](modules/liftover/README.md) | 标准染色体过滤（`00_liftover_filter`） |
 | [modules/vep_runner/README.md](modules/vep_runner/README.md) | VEP 插件与注释库安装 |
 | [modules/genos_evee_annotation/README.md](modules/genos_evee_annotation/README.md) | GENOS-VarRisk 注释与数据库构建 |
 | [modules/hla_filter/README.md](modules/hla_filter/README.md) | HLA/MHC 区行过滤 |

--- a/modules/pipeline/complete_pipeline/README.md
+++ b/modules/pipeline/complete_pipeline/README.md
@@ -3,7 +3,7 @@
 > 完整架构和数据资源下载说明见上一层 `../README.md`。本文件保留主程序/API 的详细调用说明。
 
 
-本目录包含 FastAPI 服务（`full_pipeline_api.py`）与 API 任务目录，负责把 liftover（可选）、phasing、VCF 前处理、假基因注释、VEP runner、VCF INFO 回填、GENOS-VarRisk 注释、HLA 过滤串成一个完整流程。
+本目录包含 FastAPI 服务（`full_pipeline_api.py`）与 API 任务目录，负责把 liftover（可选）、标准染色体过滤、phasing、VCF 前处理、假基因注释、VEP runner、VCF INFO 回填、GENOS-VarRisk 注释、HLA 过滤串成一个完整流程。
 
 主程序：
 
@@ -33,37 +33,42 @@ pixi run bash scripts/run_full_pipeline.sh \
 ## 流程顺序
 
 1. `00_liftover`（可选）
-   - 脚本：`modules/vcf_preprocessing/liftover_grch37/scripts/liftover_vcf.py`
+   - 脚本：`modules/vcf_preprocessing/liftover_grch37/scripts/run_liftover_vcf.py`
    - 触发：`--input-assembly GRCh37` 或 `auto` 检测到 GRCh37
    - 输出：`00_liftover/output/output.grch38.norm.vcf.gz`
 
-2. `01_phasing`（可 `--phasing no` 跳过）
+2. `00_liftover_filter`（可 `--liftover-filter-standard-chroms no` 跳过，默认开启）
+   - 脚本：`modules/liftover/scripts/filter_standard_chromosomes_vcf.py`
+   - 功能：仅保留标准染色体（1-22, X, Y, M/MT），非标准 contig 写入 ignored TSV
+   - 输出：`00_liftover_filter/input.standard_chromosomes.vcf.gz`
+
+3. `01_phasing`（可 `--phasing no` 跳过）
    - 脚本：`modules/phasing_beagle_refsupport/scripts/run_beagle_refsupport_pipeline.sh`
    - 功能：Beagle + CHN reference panel phasing/ref-support。
    - 输出：`*.original_sites.beagle_phase_merged.refsupport.vcf.gz`
 
-3. `02_vcf_preprocessing`（`--vaf` / `--regulatory-annotation` / `--ncrna-annotation` 可单独 `no`）
+4. `02_vcf_preprocessing`（`--vaf` / `--regulatory-annotation` / `--ncrna-annotation` 可单独 `no`）
    - 脚本：`modules/vcf_preprocessing/run_vcf_preprocessing.sh`
    - 功能：VAF 写入 INFO、ENCODE SCREEN cCRE 注释、GENCODE ncRNA 注释。
    - 输出：`preprocessed.regulatory.vcf.gz`
 
-4. `03_pseudogene_annotation`（可 `--pseudogene-annotation no` 跳过）
+5. `03_pseudogene_annotation`（可 `--pseudogene-annotation no` 跳过）
    - 脚本：`modules/pseudogene_annotation/scripts/annotate_pseudogene.py`
    - 功能：假基因注释，增加 `is_pseudogene`、`pseudogene_name`、`pseudogene_source` INFO 字段。
 
-5. `04_vep`
+6. `04_vep`
    - 脚本：`modules/vep_runner/scripts/run_vep_to_csv.py`
    - 输出：`04_vep/vep_output.base.csv`
 
-6. `05_vcf_info_to_csv`
+7. `05_vcf_info_to_csv`
    - 脚本：`modules/vcf_info_to_csv/scripts/add_vcf_info_to_vep_csv.py`
    - 输出：`05_vcf_info_to_csv/vep_output.with_info.csv`
 
-7. `06_genos_evee_annotation`
+8. `06_genos_evee_annotation`
    - 脚本：`modules/genos_evee_annotation/scripts/add_genos_evee_to_csv.py`
    - 输出：`06_genos_evee_annotation/vep_output.with_genos_evee.csv`
 
-8. `07_hla_filter`（可 `--hla-filter no` 跳过）
+9. `07_hla_filter`（可 `--hla-filter no` 跳过）
    - 脚本：`modules/hla_filter/scripts/filter_hla_region_csv.py`
    - 功能：删除 GRCh38 HLA/MHC 区（`chr6:28477797-33448354`）行
    - 输出：`07_hla_filter/vep_output.no_hla.csv`（**默认最终 CSV**）
@@ -105,9 +110,10 @@ bash scripts/run_full_pipeline.sh \
 | `--ncrna-annotation yes\|no` | 是，可选 | `yes` | 是否运行 ncRNA 注释。 |
 | `--pseudogene-annotation yes\|no` | 是，可选 | `yes` | 是否运行假基因注释。 |
 | `--hla-filter yes\|no` | 是，可选 | `yes` | 是否从最终宽表删除 HLA/MHC 区行。 |
+| `--liftover-filter-standard-chroms yes\|no` | 是，可选 | `yes` | 是否仅保留标准染色体；非标准 contig 写入 `00_liftover_filter/`。 |
 | `--input-assembly SPEC` | 高级覆盖 | `auto` | `auto` / `GRCh37` / `GRCh38`；GRCh37 时在 phasing 前 liftover。 |
 | `--sample-id ID` | 高级覆盖 | `auto` | 样本名。默认由 phasing 模块自动识别；特殊情况下可手动指定。 |
-| `--chromosomes SPEC` | 高级覆盖 | `1-22` | 要运行的染色体。示例：`22`、`1`、`1-22`、`1,3,5`。测试小 VCF 时常用 `1` 或 `22`。 |
+| `--chromosomes SPEC` | 高级覆盖 | `auto` | Beagle 目标染色体。示例：`22`、`1`、`1-22`、`1,3,5`。 |
 | `--ref-dir DIR` | 高级覆盖 | `$FULL_PIPELINE_REF_DIR`（默认见主 README） | Beagle CHN reference panel 目录。 |
 | `--beagle-jar FILE` | 高级覆盖 | `$FULL_PIPELINE_BEAGLE_JAR`（默认见主 README） | Beagle jar 路径。 |
 | `--ccre-bed FILE` | 高级覆盖 | V3 内置 cCRE BED | ENCODE SCREEN cCRE slim BED.GZ。 |
@@ -292,10 +298,11 @@ API 的字段和主程序参数一一对应。常规字段和高级覆盖字段�
 | `ncrna_annotation` | `--ncrna-annotation` | 是，可选 | 是否运行 ncRNA 注释，默认 `yes`。 |
 | `pseudogene_annotation` | `--pseudogene-annotation` | 是，可选 | 是否运行假基因注释，默认 `yes`。 |
 | `hla_filter` | `--hla-filter` | 是，可选 | 是否删除 HLA/MHC 区行，默认 `yes`。 |
+| `liftover_filter_standard_chroms` | `--liftover-filter-standard-chroms` | 是，可选 | 是否仅保留标准染色体，默认 `yes`。 |
 | `input_assembly` | `--input-assembly` | 高级覆盖 | `auto` / `GRCh37` / `GRCh38`。 |
 | `hpo_file` | `--hpo-id` | 是，可选 | 仅 `/run-upload` 支持，上传 TXT 后自动解析并合并到 `hpo_id`。 |
 | `sample_id` | `--sample-id` | 高级覆盖 | 样本名，默认 `auto`。 |
-| `chromosomes` | `--chromosomes` | 高级覆盖 | 覆盖默认 `1-22`。例如测试 VCF 只有 chr1 时传 `"1"`。 |
+| `chromosomes` | `--chromosomes` | 高级覆盖 | 覆盖默认 `auto`。例如测试 VCF 只有 chr1 时传 `"1"`。 |
 | `ref_dir` | `--ref-dir` | 高级覆盖 | CHN reference panel 目录。 |
 | `beagle_jar` | `--beagle-jar` | 高级覆盖 | Beagle jar 路径。 |
 | `ccre_bed` | `--ccre-bed` | 高级覆盖 | cCRE BED.GZ。 |
@@ -350,6 +357,8 @@ curl -X POST http://127.0.0.1:18081/run \
 | 路径 | 说明 |
 |---|---|
 | `<out-dir>/00_input/*.vcf.gz` | 如果输入是未压缩 `.vcf`，这里保存自动压缩后的 VCF。 |
+| `<out-dir>/00_liftover_filter/input.standard_chromosomes.vcf.gz` | 标准染色体过滤后的 VCF。 |
+| `<out-dir>/00_liftover_filter/input.ignored_nonstandard_chromosomes.tsv` | 被过滤的非标准 contig 变异。 |
 | `<out-dir>/01_phasing/*.vcf.gz` | phasing/ref-support 后的 VCF。 |
 | `<out-dir>/02_vcf_preprocessing/preprocessed.regulatory.vcf.gz` | VAF + CRE/cCRE + ncRNA 注释后的 VCF。 |
 | `<out-dir>/03_pseudogene_annotation/preprocessed.pseudogene_annotated.vcf.gz` | 假基因注释后的 VCF。 |

--- a/modules/pipeline/complete_pipeline/full_pipeline_api.py
+++ b/modules/pipeline/complete_pipeline/full_pipeline_api.py
@@ -58,6 +58,10 @@ class RunRequest(BaseModel):
     ncrna_annotation: str = Field("yes", description="Run GENCODE ncRNA annotation before VEP: yes or no")
     pseudogene_annotation: str = Field("yes", description="Run pseudogene annotation before VEP: yes or no")
     hla_filter: str = Field("yes", description="Remove GRCh38 HLA/MHC region rows from final wide CSV: yes or no")
+    liftover_filter_standard_chroms: str = Field(
+        "yes",
+        description="Before downstream/Liftover-sensitive steps, keep only standard chromosomes and log ignored nonstandard contigs: yes or no",
+    )
     input_assembly: Optional[str] = Field(
         None,
         description="Input VCF assembly: auto, GRCh37, or GRCh38; GRCh37 triggers liftover before phasing",
@@ -288,6 +292,7 @@ def build_command(req: RunRequest, output_dir: Path) -> list[str]:
     add_option("--ncrna-annotation", req.ncrna_annotation)
     add_option("--pseudogene-annotation", req.pseudogene_annotation)
     add_option("--hla-filter", req.hla_filter)
+    add_option("--liftover-filter-standard-chroms", req.liftover_filter_standard_chroms)
     add_option("--input-assembly", req.input_assembly)
     add_option("--sample-id", req.sample_id)
     add_option("--chromosomes", req.chromosomes)
@@ -366,6 +371,7 @@ def health() -> dict:
             "ncrna_annotation",
             "pseudogene_annotation",
             "hla_filter",
+            "liftover_filter_standard_chroms",
             "input_assembly",
         ],
         "execution": {
@@ -384,6 +390,8 @@ def health() -> dict:
             "sample_id": "auto",
             "chromosomes": "auto",
             "chromosomes_scope": "Default auto: Beagle runs on every patient contig with a reference panel; X/Y/MT and other unsupported contigs are preserved unchanged for VEP",
+            "liftover_filter_standard_chroms": "yes",
+            "liftover_standard_chromosomes": "1-22,X,Y,MT plus chr-prefixed equivalents; nonstandard contigs are written to 00_liftover_filter/input.ignored_nonstandard_chromosomes.tsv",
             "ref_dir": str(DEFAULT_REF_DIR),
             "beagle_jar": str(DEFAULT_BEAGLE_JAR),
             "java_bin": DEFAULT_JAVA_BIN,
@@ -457,6 +465,7 @@ def submit_upload(
     ncrna_annotation: str = Form("yes"),
     pseudogene_annotation: str = Form("yes"),
     hla_filter: str = Form("yes"),
+    liftover_filter_standard_chroms: str = Form("yes"),
     input_assembly: Optional[str] = Form(None),
     hpo_file: UploadFile | None = File(None, description="Optional TXT file containing HPO IDs; one per line or separated by comma/space/semicolon"),
     sample_id: Optional[str] = Form(None),
@@ -492,6 +501,7 @@ def submit_upload(
         ncrna_annotation=ncrna_annotation,
         pseudogene_annotation=pseudogene_annotation,
         hla_filter=hla_filter,
+        liftover_filter_standard_chroms=liftover_filter_standard_chroms,
         input_assembly=input_assembly,
         sample_id=sample_id,
         chromosomes=chromosomes,

--- a/modules/pipeline/modules/liftover/README.md
+++ b/modules/pipeline/modules/liftover/README.md
@@ -1,0 +1,63 @@
+# 标准染色体过滤
+
+在 phasing / VEP 等下游步骤之前，从 VCF 中**仅保留标准人类染色体**，并记录被忽略的非标准 contig 变异。
+
+## 标准染色体定义
+
+保留以下染色体（含 `chr` 前缀版本）：
+
+- 常染色体 `1-22`
+- 性染色体 `X`、`Y`
+- 线粒体 `M` / `MT`
+
+其他 contig（如 `chrUn_*`、`*_random`、`*_alt`、HLA scaffold、decoy）视为非标准，默认过滤并写入 ignored TSV。
+
+## 主流程集成
+
+由 `scripts/run_full_pipeline.sh` 在 **GRCh37 liftover（可选）之后、phasing 之前** 调用：
+
+```bash
+bash scripts/run_full_pipeline.sh \
+  --input-vcf sample.vcf.gz \
+  --out-dir ./output \
+  --liftover-filter-standard-chroms yes   # 默认 yes
+```
+
+关闭过滤：
+
+```bash
+bash scripts/run_full_pipeline.sh \
+  --input-vcf sample.vcf.gz \
+  --out-dir ./output \
+  --liftover-filter-standard-chroms no
+```
+
+## 脚本
+
+| 文件 | 说明 |
+|------|------|
+| `scripts/filter_standard_chromosomes_vcf.py` | 过滤逻辑；读取 `.vcf` / `.vcf.gz`，输出未压缩 VCF |
+
+单独运行示例：
+
+```bash
+python3 modules/liftover/scripts/filter_standard_chromosomes_vcf.py \
+  --input-vcf input.vcf.gz \
+  --output-vcf output.standard.vcf \
+  --ignored-tsv ignored.tsv \
+  --stats-tsv stats.tsv
+```
+
+## 输出（相对 `--out-dir`）
+
+| 路径 | 说明 |
+|------|------|
+| `00_liftover_filter/input.standard_chromosomes.vcf.gz` | 过滤后的 VCF |
+| `00_liftover_filter/input.ignored_nonstandard_chromosomes.tsv` | 被忽略的变异（`chrom pos id ref alt reason`） |
+| `00_liftover_filter/input.standard_chromosome_filter.stats.tsv` | 过滤统计 |
+
+`full_pipeline.outputs.tsv` 中会写入 `liftover_filter_standard_chroms`、`liftover_standard_vcf`、`liftover_ignored_nonstandard_tsv` 等字段。
+
+## API
+
+FastAPI 字段 `liftover_filter_standard_chroms`（默认 `"yes"`），对应 CLI `--liftover-filter-standard-chroms`。详见 [`complete_pipeline/README.md`](../../complete_pipeline/README.md)。

--- a/modules/pipeline/modules/liftover/scripts/filter_standard_chromosomes_vcf.py
+++ b/modules/pipeline/modules/liftover/scripts/filter_standard_chromosomes_vcf.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import gzip
+from pathlib import Path
+
+
+AUTOSOMES = {str(i) for i in range(1, 23)}
+SEX_CHROMS = {"X", "Y"}
+MITO_CHROMS = {"M", "MT"}
+STANDARD = AUTOSOMES | SEX_CHROMS | MITO_CHROMS
+
+
+def open_text(path: Path, mode: str):
+    if "r" in mode and path.suffix == ".gz":
+        return gzip.open(path, mode + "t", encoding="utf-8")
+    return path.open(mode, encoding="utf-8")
+
+
+def canonical_chrom(chrom: str) -> str:
+    value = chrom.strip()
+    if value.lower().startswith("chr"):
+        value = value[3:]
+    value = value.upper()
+    if value == "M":
+        return "MT"
+    return value
+
+
+def is_standard_chrom(chrom: str) -> bool:
+    return canonical_chrom(chrom) in STANDARD
+
+
+def contig_id_from_header(line: str) -> str | None:
+    prefix = "##contig=<ID="
+    if not line.startswith(prefix):
+        return None
+    rest = line[len(prefix) :]
+    for sep in (",", ">"):
+        idx = rest.find(sep)
+        if idx >= 0:
+            return rest[:idx]
+    return rest.strip()
+
+
+def filter_vcf(input_vcf: Path, output_vcf: Path, ignored_tsv: Path, stats_tsv: Path) -> None:
+    output_vcf.parent.mkdir(parents=True, exist_ok=True)
+    ignored_tsv.parent.mkdir(parents=True, exist_ok=True)
+    stats_tsv.parent.mkdir(parents=True, exist_ok=True)
+
+    total_records = 0
+    kept_records = 0
+    ignored_records = 0
+    ignored_contigs: dict[str, int] = {}
+
+    with open_text(input_vcf, "r") as src, output_vcf.open("w", encoding="utf-8") as out, ignored_tsv.open(
+        "w", encoding="utf-8"
+    ) as ignored:
+        ignored.write("chrom\tpos\tid\tref\talt\treason\n")
+        for line in src:
+            if line.startswith("##contig=<ID="):
+                contig = contig_id_from_header(line)
+                if contig and not is_standard_chrom(contig):
+                    continue
+                out.write(line)
+                continue
+            if line.startswith("#"):
+                out.write(line)
+                continue
+
+            total_records += 1
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 5:
+                ignored_records += 1
+                ignored.write(".\t.\t.\t.\t.\tmalformed_vcf_record\n")
+                continue
+
+            chrom, pos, var_id, ref, alt = fields[:5]
+            if is_standard_chrom(chrom):
+                kept_records += 1
+                out.write(line)
+            else:
+                ignored_records += 1
+                ignored_contigs[chrom] = ignored_contigs.get(chrom, 0) + 1
+                ignored.write(f"{chrom}\t{pos}\t{var_id}\t{ref}\t{alt}\tnonstandard_chromosome\n")
+
+    with stats_tsv.open("w", encoding="utf-8") as stats:
+        stats.write("metric\tvalue\n")
+        stats.write(f"input_records\t{total_records}\n")
+        stats.write(f"kept_standard_records\t{kept_records}\n")
+        stats.write(f"ignored_nonstandard_records\t{ignored_records}\n")
+        stats.write(f"ignored_nonstandard_contig_count\t{len(ignored_contigs)}\n")
+        for chrom, count in sorted(ignored_contigs.items()):
+            stats.write(f"ignored_contig:{chrom}\t{count}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Keep only standard human chromosomes in a VCF and log ignored nonstandard records."
+    )
+    parser.add_argument("--input-vcf", required=True, type=Path)
+    parser.add_argument("--output-vcf", required=True, type=Path, help="Uncompressed VCF output path")
+    parser.add_argument("--ignored-tsv", required=True, type=Path)
+    parser.add_argument("--stats-tsv", required=True, type=Path)
+    args = parser.parse_args()
+
+    filter_vcf(args.input_vcf, args.output_vcf, args.ignored_tsv, args.stats_tsv)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/pipeline/scripts/run_full_pipeline.sh
+++ b/modules/pipeline/scripts/run_full_pipeline.sh
@@ -9,6 +9,7 @@ PHASING_SCRIPT="${ROOT}/modules/phasing_beagle_refsupport/scripts/run_beagle_ref
 RESTORE_UNPHASED_SCRIPT="${ROOT}/modules/phasing_beagle_refsupport/scripts/restore_unphased_variants.sh"
 PREPROCESS_SCRIPT="${ROOT}/modules/vcf_preprocessing/run_vcf_preprocessing.sh"
 LIFTOVER_PY="${OPENRARE_LIFTOVER_SCRIPT}"
+LIFTOVER_FILTER_SCRIPT="${ROOT}/modules/liftover/scripts/filter_standard_chromosomes_vcf.py"
 PSEUDOGENE_PY="${ROOT}/modules/pseudogene_annotation/scripts/annotate_pseudogene.py"
 VEP_SCRIPT="${ROOT}/modules/vep_runner/scripts/run_vep_to_csv.py"
 INFO_TO_CSV_SCRIPT="${ROOT}/modules/vcf_info_to_csv/scripts/add_vcf_info_to_vep_csv.py"
@@ -36,6 +37,9 @@ Common optional:
   --ncrna-annotation yes|no       Whether to add GENCODE ncRNA INFO fields before VEP; default: yes
   --pseudogene-annotation yes|no  Whether to run pseudogene annotation before VEP; default: yes
   --hla-filter yes|no       Whether to remove GRCh38 HLA/MHC rows from final wide CSV; default: yes
+  --liftover-filter-standard-chroms yes|no
+                            Keep only standard chromosomes before downstream processing; default: yes.
+                            Nonstandard contigs are ignored and written to 00_liftover_filter/*.ignored_nonstandard.tsv
 
 Advanced optional overrides, usually not needed:
   --sample-id ID            Sample ID used for output prefixes; default: auto
@@ -82,6 +86,7 @@ REGULATORY_ANNOTATION=yes
 NCRNA_ANNOTATION=yes
 PSEUDOGENE_ANNOTATION=yes
 HLA_FILTER=yes
+LIFTOVER_FILTER_STANDARD_CHROMS=yes
 DRY_RUN=no
 
 while [[ $# -gt 0 ]]; do
@@ -107,6 +112,7 @@ while [[ $# -gt 0 ]]; do
     --ncrna-annotation) NCRNA_ANNOTATION="${2:?}"; shift 2 ;;
     --pseudogene-annotation) PSEUDOGENE_ANNOTATION="${2:?}"; shift 2 ;;
     --hla-filter) HLA_FILTER="${2:?}"; shift 2 ;;
+    --liftover-filter-standard-chroms) LIFTOVER_FILTER_STANDARD_CHROMS="${2:?}"; shift 2 ;;
     --clinical-tissue) CLINICAL_TISSUE="${2:?}"; shift 2 ;;
     --GENOS-VarRisk-db) GENOS_EVEE_DB="${2:?}"; shift 2 ;;
     --keep-raw-vep) KEEP_RAW_VEP="${2:?}"; shift 2 ;;
@@ -135,6 +141,7 @@ REGULATORY_ANNOTATION="$(norm_bool "$REGULATORY_ANNOTATION" --regulatory-annotat
 NCRNA_ANNOTATION="$(norm_bool "$NCRNA_ANNOTATION" --ncrna-annotation)"
 PSEUDOGENE_ANNOTATION="$(norm_bool "$PSEUDOGENE_ANNOTATION" --pseudogene-annotation)"
 HLA_FILTER="$(norm_bool "$HLA_FILTER" --hla-filter)"
+LIFTOVER_FILTER_STANDARD_CHROMS="$(norm_bool "$LIFTOVER_FILTER_STANDARD_CHROMS" --liftover-filter-standard-chroms)"
 
 if [[ "$PHASING" == yes ]]; then
   [[ -d "$REF_DIR" ]] || { echo "ERROR: ref dir not found: $REF_DIR" >&2; exit 1; }
@@ -154,6 +161,7 @@ fi
 [[ -s "$INFO_TO_CSV_SCRIPT" ]] || { echo "ERROR: INFO-to-CSV script not found: $INFO_TO_CSV_SCRIPT" >&2; exit 1; }
 [[ -s "$ENSURE_HEADERS_SCRIPT" ]] || { echo "ERROR: ensure-header script not found: $ENSURE_HEADERS_SCRIPT" >&2; exit 1; }
 [[ -x "$RESTORE_UNPHASED_SCRIPT" ]] || { echo "ERROR: unphased-variant restore script not found or not executable: $RESTORE_UNPHASED_SCRIPT" >&2; exit 1; }
+[[ -s "$LIFTOVER_FILTER_SCRIPT" ]] || { echo "ERROR: liftover standard-chromosome filter script not found: $LIFTOVER_FILTER_SCRIPT" >&2; exit 1; }
 [[ -s "$GENOS_EVEE_SCRIPT" ]] || { echo "ERROR: GENOS-VarRisk annotation script not found: $GENOS_EVEE_SCRIPT" >&2; exit 1; }
 [[ -s "$HLA_FILTER_SCRIPT" ]] || { echo "ERROR: HLA filter script not found: $HLA_FILTER_SCRIPT" >&2; exit 1; }
 case "$INPUT_ASSEMBLY" in
@@ -164,7 +172,7 @@ case "$INPUT_ASSEMBLY" in
     ;;
 esac
 
-mkdir -p "$OUT_DIR"/{00_input,00_liftover,01_phasing,02_vcf_preprocessing,03_pseudogene_annotation,04_vep,05_vcf_info_to_csv,06_genos_evee_annotation,07_hla_filter,logs}
+mkdir -p "$OUT_DIR"/{00_input,00_liftover,00_liftover_filter,01_phasing,02_vcf_preprocessing,03_pseudogene_annotation,04_vep,05_vcf_info_to_csv,06_genos_evee_annotation,07_hla_filter,logs}
 LOG="${OUT_DIR}/logs/full_pipeline.log"
 SUMMARY="${OUT_DIR}/full_pipeline.outputs.tsv"
 exec > >(tee -a "$LOG") 2>&1
@@ -265,6 +273,29 @@ elif [[ "$resolved_assembly" == GRCh38 ]]; then
   echo "[liftover] skipped (input assembly GRCh38)"
 else
   echo "[liftover] skipped (assembly=${resolved_assembly}; expected GRCh37 to liftover)"
+fi
+
+liftover_input_vcf="$PIPELINE_INPUT_VCF"
+liftover_standard_vcf="$PIPELINE_INPUT_VCF"
+liftover_ignored_tsv="${OUT_DIR}/00_liftover_filter/input.ignored_nonstandard_chromosomes.tsv"
+liftover_stats_tsv="${OUT_DIR}/00_liftover_filter/input.standard_chromosome_filter.stats.tsv"
+if [[ "$LIFTOVER_FILTER_STANDARD_CHROMS" == yes ]]; then
+  liftover_standard_plain="${OUT_DIR}/00_liftover_filter/input.standard_chromosomes.vcf"
+  liftover_standard_vcf="${liftover_standard_plain}.gz"
+  run_cmd python3 "$LIFTOVER_FILTER_SCRIPT" \
+    --input-vcf "$PIPELINE_INPUT_VCF" \
+    --output-vcf "$liftover_standard_plain" \
+    --ignored-tsv "$liftover_ignored_tsv" \
+    --stats-tsv "$liftover_stats_tsv"
+  run_cmd bgzip -f "$liftover_standard_plain"
+  if command -v bcftools >/dev/null 2>&1; then
+    run_cmd bcftools index -f -t "$liftover_standard_vcf"
+  else
+    run_cmd tabix -f -p vcf "$liftover_standard_vcf"
+  fi
+  PIPELINE_INPUT_VCF="$liftover_standard_vcf"
+else
+  printf '[%s] SKIP liftover standard-chromosome filter: using normalized input VCF directly: %s\n' "$(date '+%F %T')" "$PIPELINE_INPUT_VCF"
 fi
 
 sample_arg=()
@@ -413,6 +444,11 @@ fi
     printf 'liftover_manifest\t%s\n' "$liftover_manifest"
   fi
   printf 'input_assembly\t%s\n' "$resolved_assembly"
+  printf 'liftover_filter_standard_chroms\t%s\n' "$LIFTOVER_FILTER_STANDARD_CHROMS"
+  printf 'liftover_input_vcf\t%s\n' "$liftover_input_vcf"
+  printf 'liftover_standard_vcf\t%s\n' "$liftover_standard_vcf"
+  printf 'liftover_ignored_nonstandard_tsv\t%s\n' "$liftover_ignored_tsv"
+  printf 'liftover_filter_stats\t%s\n' "$liftover_stats_tsv"
   printf 'phasing\t%s\n' "$PHASING"
   printf 'vaf\t%s\n' "$VAF"
   printf 'regulatory_annotation\t%s\n' "$REGULATORY_ANNOTATION"


### PR DESCRIPTION
在 phasing 前默认仅保留 1-22/X/Y/MT，并同步更新 CLI、API 与相关文档。 @wangz1lu 