### PR TITLE
docs: add HPO TPM data bundle instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ $OPENRARE_PUBLIC_DATA_ROOT/
     └── Pseudogene.org/Human90/Human90.txt
 ```
 
+HPO-to-tissue resources used by step 04 are provided as a release asset:
+
+```bash
+mkdir -p "${OPENRARE_DATA_ROOT}/vep_data"
+curl -L -o /tmp/hpo_tpm.zip \
+  https://github.com/OpenRare2026/OpenRare/releases/download/data-hpo-tpm-v1/hpo_tpm.zip
+unzip -q /tmp/hpo_tpm.zip -d "${OPENRARE_DATA_ROOT}/vep_data"
+test -f "${OPENRARE_DATA_ROOT}/vep_data/hpo_tpm/phenotype_to_anatomy.txt"
+```
+
 **ppi_score** — HGNC, HPO ontology, OMIM, StringDB (~5 GB):
 
 ```bash
@@ -250,6 +260,7 @@ pkill -f "gateway.main"
 | CADD | <https://cadd.gs.washington.edu/download> |
 | SpliceAI | <https://github.com/Illumina/SpliceAI> |
 | GTEx | <https://gtexportal.org/home/datasets> |
+| HPO→tissue TPM bundle | <https://github.com/OpenRare2026/OpenRare/releases/download/data-hpo-tpm-v1/hpo_tpm.zip> |
 | SapBERT model | <https://huggingface.co/pritamdeka/SapBERT-mnli-snli-scinli-scitail-mednli-stsb> |
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -195,6 +195,16 @@ $OPENRARE_PUBLIC_DATA_ROOT/
     └── Pseudogene.org/Human90/Human90.txt
 ```
 
+04 步使用的 HPO→tissue 资源作为 release 附件提供：
+
+```bash
+mkdir -p "${OPENRARE_DATA_ROOT}/vep_data"
+curl -L -o /tmp/hpo_tpm.zip \
+  https://github.com/OpenRare2026/OpenRare/releases/download/data-hpo-tpm-v1/hpo_tpm.zip
+unzip -q /tmp/hpo_tpm.zip -d "${OPENRARE_DATA_ROOT}/vep_data"
+test -f "${OPENRARE_DATA_ROOT}/vep_data/hpo_tpm/phenotype_to_anatomy.txt"
+```
+
 **ppi_score** — HGNC、HPO 本体、OMIM、StringDB（~5 GB）：
 
 ```bash
@@ -250,6 +260,7 @@ pkill -f "gateway.main"
 | CADD | <https://cadd.gs.washington.edu/download> |
 | SpliceAI | <https://github.com/Illumina/SpliceAI> |
 | GTEx | <https://gtexportal.org/home/datasets> |
+| HPO→tissue TPM 数据包 | <https://github.com/OpenRare2026/OpenRare/releases/download/data-hpo-tpm-v1/hpo_tpm.zip> |
 | SapBERT 模型 | <https://huggingface.co/pritamdeka/SapBERT-mnli-snli-scinli-scitail-mednli-stsb> |
 
 ---

--- a/modules/pipeline/EXTERNAL_PATHS.md
+++ b/modules/pipeline/EXTERNAL_PATHS.md
@@ -28,6 +28,16 @@
 | `LIFTOVER_CONFIG` | 见 `.env.example` | liftover TOML（chain、GRCh38 参考、picard 路径） |
 | `OPENRARE_API_TEST_VCF` | 无 | API 集成测试输入 VCF（可选） |
 
+04 步需要的 HPO→tissue TPM 数据包可从 GitHub Release 下载，并解压到默认位置：
+
+```bash
+mkdir -p "${OPENRARE_DATA_ROOT}/vep_data"
+curl -L -o /tmp/hpo_tpm.zip \
+  https://github.com/OpenRare2026/OpenRare/releases/download/data-hpo-tpm-v1/hpo_tpm.zip
+unzip -q /tmp/hpo_tpm.zip -d "${OPENRARE_DATA_ROOT}/vep_data"
+test -f "${OPENRARE_DATA_ROOT}/vep_data/hpo_tpm/phenotype_to_anatomy.txt"
+```
+
 解析逻辑：
 
 - Shell：[`config/paths.sh`](config/paths.sh)（绝对路径原样使用；相对路径相对 `modules/pipeline` 展开）

--- a/modules/pipeline/modules/vep_runner/README.md
+++ b/modules/pipeline/modules/vep_runner/README.md
@@ -170,6 +170,16 @@ pixi run tabix -p vcf clinvar_20260523.vcf.gz
 | GTEx v11 transcript TPM parquet | `vep_data/GTEx/v11/expression/gtex_v11_transcript_tpm.parquet`（由 [`gtex_preprocess`](../../resource_mock/gtex_preprocess/README.md) 从官网数据预计算） |
 | HPO→tissue 映射 | `vep_data/hpo_tpm/` |
 
+HPO→tissue 映射数据包下载方式：
+
+```bash
+mkdir -p "${OPENRARE_DATA_ROOT}/vep_data"
+curl -L -o /tmp/hpo_tpm.zip \
+  https://github.com/OpenRare2026/OpenRare/releases/download/data-hpo-tpm-v1/hpo_tpm.zip
+unzip -q /tmp/hpo_tpm.zip -d "${OPENRARE_DATA_ROOT}/vep_data"
+test -f "${OPENRARE_DATA_ROOT}/vep_data/hpo_tpm/phenotype_to_anatomy.txt"
+```
+
 ## 5. 校验安装
 
 ```bash


### PR DESCRIPTION
## Summary
- publish hpo_tpm.zip as the data-hpo-tpm-v1 release asset
- document how to download and extract it to `/vep_data/hpo_tpm`
- add the bundle to the root data download references

## Validation
- verified zip integrity with `unzip -t`
- verified extracted layout contains `vep_data/hpo_tpm/phenotype_to_anatomy.txt`
- confirmed GitHub release asset URL resolves