### PR TITLE
security: 服务默认绑定回环地址 (Fixes #15)

### DIFF
--- a/gateway/src/gateway/main.py
+++ b/gateway/src/gateway/main.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import contextlib
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -37,6 +38,15 @@ def find_root(start: Path) -> Path:
 
 
 REPO_ROOT = find_root(Path(__file__).resolve())
+
+# ── Bind address ──────────────────────────────────────────────────────
+# Default to loopback: the gateway fronts modules that hold patient
+# genomic data and currently carry no authentication layer, so it must
+# not be reachable from the LAN unless the operator opts in explicitly.
+# Set OPENRARE_HOST=0.0.0.0 only behind an authenticating reverse proxy
+# (containers publish ports themselves and need no change here).
+HOST = os.getenv("OPENRARE_HOST", "127.0.0.1")
+PORT = int(os.getenv("OPENRARE_PORT", "8000"))
 
 # ── Module registry ───────────────────────────────────────────────────
 # Each module defines how it's launched inside its own pixi environment.
@@ -192,7 +202,7 @@ async def lifespan(app: FastAPI):
     ready = await wait_healthy()
     app.state.ready_modules = ready
     app.state.client = httpx.AsyncClient(timeout=120.0)
-    print(f"[gateway] ready on http://0.0.0.0:8000 — {len(ready)}/{len(MODULES)} modules up", flush=True)
+    print(f"[gateway] ready on http://{HOST}:{PORT} — {len(ready)}/{len(MODULES)} modules up", flush=True)
     yield
     await app.state.client.aclose()
     stop_modules()
@@ -266,7 +276,7 @@ async def pipeline_status():
 
 
 def main() -> None:
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=HOST, port=PORT)
 
 
 if __name__ == "__main__":

--- a/modules/RareSystem/backend/main.py
+++ b/modules/RareSystem/backend/main.py
@@ -31,6 +31,11 @@ if env_path.exists():
     from dotenv import load_dotenv
     load_dotenv(env_path)
 
+# Loopback by default: this API serves patient genomic data and has no
+# authentication layer yet, so it must not listen on every interface unless
+# the operator opts in. Containers set API_HOST=0.0.0.0 explicitly — the
+# container boundary is what limits exposure there.
+API_HOST = os.getenv("API_HOST", "127.0.0.1")
 API_PORT = int(os.getenv("API_PORT", "8000"))
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:8888,http://127.0.0.1:8888,http://localhost:8181,http://127.0.0.1:8181").split(",")
 
@@ -155,4 +160,4 @@ app.include_router(report_router, prefix="/api", tags=["report"])
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=API_PORT)
+    uvicorn.run(app, host=API_HOST, port=API_PORT)

--- a/modules/RareSystem/backend/run.py
+++ b/modules/RareSystem/backend/run.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def main():
-    host = os.getenv("API_HOST", "0.0.0.0")
+    host = os.getenv("API_HOST", "127.0.0.1")
     port = int(os.getenv("API_PORT", "8000"))
     reload = os.getenv("API_RELOAD", "true").lower() == "true"
     env = os.getenv("ENVIRONMENT", "development")

--- a/modules/RareSystem/docker/start.sh
+++ b/modules/RareSystem/docker/start.sh
@@ -11,6 +11,10 @@ mkdir -p /app/data /app/logs /var/log/supervisor /var/log/nginx
 # Set default environment variables
 export DATABASE_URL="${DATABASE_URL:-sqlite:////app/data/rare_disease_diagnosis.db}"
 export LOG_LEVEL="${LOG_LEVEL:-INFO}"
+# Inside the container 0.0.0.0 is correct and required: the container
+# boundary is what limits exposure, and `docker run -p` cannot reach a
+# process bound to the container's loopback. Host-level defaults are
+# loopback instead — see modules/RareSystem/backend/main.py.
 export API_HOST="${API_HOST:-0.0.0.0}"
 export API_PORT="${API_PORT:-8000}"
 

--- a/modules/RareSystem/frontend/vite.config.ts
+++ b/modules/RareSystem/frontend/vite.config.ts
@@ -11,7 +11,10 @@ export default defineConfig({
     },
   },
   server: {
-    host: '0.0.0.0',
+    // Loopback by default — the dev server proxies /api to the backend,
+    // so exposing it on the LAN exposes patient data with it. Override with
+    // `vite --host 0.0.0.0` when you deliberately need remote access.
+    host: '127.0.0.1',
     port: 8888,
     proxy: {
       '/api': {

--- a/modules/RareSystem/pixi.toml
+++ b/modules/RareSystem/pixi.toml
@@ -65,10 +65,10 @@ neo4j = ">=6.2"
 
 [tasks]
 # Backend
-dev = { cmd = "uvicorn main:app --reload --host 0.0.0.0 --port 18000", cwd = "backend", default-environment = "dev" }
-start = { cmd = "uvicorn main:app --host 0.0.0.0 --port 18000", cwd = "backend" }
-frontend = { cmd = "npx vite --host 0.0.0.0 --port 8888", cwd = "frontend", default-environment = "dev" }
-dev-full = { cmd = "bash -c 'cd backend && uvicorn main:app --reload --host 0.0.0.0 --port 18000 & cd frontend && npx vite --host 0.0.0.0 --port 8888 & wait'", default-environment = "dev" }
+dev = { cmd = "uvicorn main:app --reload --host 127.0.0.1 --port 18000", cwd = "backend", default-environment = "dev" }
+start = { cmd = "uvicorn main:app --host 127.0.0.1 --port 18000", cwd = "backend" }
+frontend = { cmd = "npx vite --host 127.0.0.1 --port 8888", cwd = "frontend", default-environment = "dev" }
+dev-full = { cmd = "bash -c 'cd backend && uvicorn main:app --reload --host 127.0.0.1 --port 18000 & cd frontend && npx vite --host 127.0.0.1 --port 8888 & wait'", default-environment = "dev" }
 # Database
 migrate = { cmd = "alembic upgrade head", cwd = "backend" }
 makemigration = { cmd = "alembic revision --autogenerate -m", cwd = "backend" }

--- a/modules/pipeline/pixi.toml
+++ b/modules/pipeline/pixi.toml
@@ -39,7 +39,7 @@ pipeline-test = { cmd = [
 ]}
 api = { cmd = [
   "bash", "-c",
-  "FULL_PIPELINE_API_HOST=${FULL_PIPELINE_API_HOST:-0.0.0.0} FULL_PIPELINE_API_PORT=${FULL_PIPELINE_API_PORT:-18901} exec bash scripts/start_full_pipeline_api.sh",
+  "FULL_PIPELINE_API_HOST=${FULL_PIPELINE_API_HOST:-${OPENRARE_HOST:-127.0.0.1}} FULL_PIPELINE_API_PORT=${FULL_PIPELINE_API_PORT:-18901} exec bash scripts/start_full_pipeline_api.sh",
 ]}
 api-test = { cmd = ["bash", "test/run_api_integration_test.sh"] }
 mock-smoke-test = { cmd = ["bash", "test/run_mock_smoke_dryrun.sh"] }

--- a/modules/pipeline/scripts/start_full_pipeline_api.sh
+++ b/modules/pipeline/scripts/start_full_pipeline_api.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-HOST="${FULL_PIPELINE_API_HOST:-0.0.0.0}"
+HOST="${FULL_PIPELINE_API_HOST:-${OPENRARE_HOST:-127.0.0.1}}"
 PORT="${FULL_PIPELINE_API_PORT:-18901}"
 cd "$ROOT"
 exec python3 -m uvicorn complete_pipeline.full_pipeline_api:app --host "$HOST" --port "$PORT" --workers 1

--- a/modules/pixi_RAG-HPO/README.md
+++ b/modules/pixi_RAG-HPO/README.md
@@ -55,7 +55,7 @@ cp .env.example .env
 
 ```bash
 pixi run serve
-# → Uvicorn running on http://0.0.0.0:8000
+# → Uvicorn running on http://127.0.0.1:8000
 ```
 
 ### 验证

--- a/modules/pixi_RAG-HPO/pixi.toml
+++ b/modules/pixi_RAG-HPO/pixi.toml
@@ -7,7 +7,7 @@ channels = ["conda-forge"]
 platforms = ["linux-64", "osx-arm64"]
 
 [tasks]
-serve = { cmd = "uvicorn server:app --host 0.0.0.0 --port 8000", cwd = "src", env = { PYTHONPATH = "src" } }
+serve = { cmd = "uvicorn server:app --host 127.0.0.1 --port 8000", cwd = "src", env = { PYTHONPATH = "src" } }
 cli = { cmd = "python rag_hpo.py", cwd = "src", env = { PYTHONPATH = "src" } }
 build-db = { cmd = "python build_vector_db.py", cwd = "src", env = { PYTHONPATH = "src" } }
 test = "pytest tests/"
@@ -44,7 +44,7 @@ ruff = "*"
 gunicorn = "*"
 
 [feature.prod.tasks]
-serve-prod = "gunicorn src.server:app -w 4 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000"
+serve-prod = "gunicorn src.server:app -w 4 -k uvicorn.workers.UvicornWorker -b 127.0.0.1:8000"
 
 [environments]
 test = ["test"]

--- a/modules/pixi_RAG-HPO/src/server.py
+++ b/modules/pixi_RAG-HPO/src/server.py
@@ -2,7 +2,7 @@
 """FastAPI server for RAG-HPO pipeline.
 
 Start with:
-    uvicorn dev.server:app --host 0.0.0.0 --port 8000
+    uvicorn dev.server:app --host 127.0.0.1 --port 8000
 """
 
 from __future__ import annotations

--- a/modules/pixi_phenotype_score/scripts/start_api.py
+++ b/modules/pixi_phenotype_score/scripts/start_api.py
@@ -46,7 +46,7 @@ def main() -> None:
         uvicorn.run(
             "phenotype_hpo_score_api:app",
             app_dir=str(SRC_DIR),
-            host="0.0.0.0",
+            host=os.getenv("OPENRARE_HOST", "127.0.0.1"),
             port=7773,
             log_config=log_config,
         )

--- a/modules/pixi_ppi_score/.env.example
+++ b/modules/pixi_ppi_score/.env.example
@@ -1,4 +1,6 @@
-RARE_PPI_HOST=0.0.0.0
+# Loopback by default — this service has no authentication layer.
+# Only widen it (e.g. 0.0.0.0) behind an authenticating reverse proxy.
+RARE_PPI_HOST=127.0.0.1
 RARE_PPI_PORT=9000
 RARE_PPI_DATA_DIR=../../../data
 RARE_PPI_CACHE_DIR=../../../data/cache

--- a/modules/pixi_ppi_score/scripts/run_api.sh
+++ b/modules/pixi_ppi_score/scripts/run_api.sh
@@ -14,5 +14,5 @@ export RARE_PPI_RESPONSE_PATH_BASE="${RARE_PPI_RESPONSE_PATH_BASE:-$PROJECT_DIR}
 mkdir -p "$RARE_PPI_OUTPUT_DIR" "$RARE_PPI_UPLOAD_DIR"
 
 exec python -m uvicorn app.api:app \
-  --host "${RARE_PPI_HOST:-0.0.0.0}" \
+  --host "${RARE_PPI_HOST:-${OPENRARE_HOST:-127.0.0.1}}" \
   --port "${RARE_PPI_PORT:-9000}"

--- a/modules/pixi_rare_sort_fastapi/main.py
+++ b/modules/pixi_rare_sort_fastapi/main.py
@@ -115,4 +115,4 @@ def list_jobs():
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=5000)
+    uvicorn.run(app, host=os.getenv("OPENRARE_HOST", "127.0.0.1"), port=5000)

--- a/modules/pixi_rare_sort_fastapi/pixi.toml
+++ b/modules/pixi_rare_sort_fastapi/pixi.toml
@@ -6,7 +6,7 @@ platforms = ["osx-arm64"]
 version = "0.1.0"
 
 [tasks]
-start = "uvicorn main:app --host 0.0.0.0 --port 5000 --reload"
+start = "uvicorn main:app --host 127.0.0.1 --port 5000 --reload"
 
 [dependencies]
 python = ">=3.11"

--- a/modules/pixi_report/README.md
+++ b/modules/pixi_report/README.md
@@ -122,7 +122,7 @@ cd modules/pixi_report
 pixi install
 cp .env.example .env    # 配置 LLM、MCP 等（见下文「数据部署」）
 
-pixi run api            # http://0.0.0.0:8800
+pixi run api            # http://127.0.0.1:8800
 pixi run health
 pixi run test-api       # curl 全流程测试
 ```

--- a/modules/pixi_report/api/main.py
+++ b/modules/pixi_report/api/main.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
@@ -128,7 +129,7 @@ async def download_report_md(run_id: str) -> FileResponse:
 def main() -> None:
     import uvicorn
 
-    uvicorn.run("api.main:app", host="0.0.0.0", port=8800, reload=False)
+    uvicorn.run("api.main:app", host=os.getenv("OPENRARE_HOST", "127.0.0.1"), port=8800, reload=False)
 
 
 if __name__ == "__main__":

--- a/modules/pixi_report/pixi.toml
+++ b/modules/pixi_report/pixi.toml
@@ -28,6 +28,6 @@ pypandoc-binary = ">=1.17"
 httpx = ">=0.27"
 
 [tasks]
-api = "uvicorn api.main:app --host 0.0.0.0 --port 8800"
+api = "uvicorn api.main:app --host 127.0.0.1 --port 8800"
 health = "python -c \"import httpx; r=httpx.get('http://127.0.0.1:8800/health', timeout=5); print(r.status_code, r.text)\""
 test-api = "bash scripts/test_api.sh"

--- a/pixi_rare_sort_fastapi/main.py
+++ b/pixi_rare_sort_fastapi/main.py
@@ -115,4 +115,4 @@ def list_jobs():
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=5000)
+    uvicorn.run(app, host=os.getenv("OPENRARE_HOST", "127.0.0.1"), port=5000)

--- a/pixi_rare_sort_fastapi/pixi.toml
+++ b/pixi_rare_sort_fastapi/pixi.toml
@@ -6,7 +6,7 @@ platforms = ["osx-arm64"]
 version = "0.1.0"
 
 [tasks]
-start = "uvicorn main:app --host 0.0.0.0 --port 5000 --reload"
+start = "uvicorn main:app --host 127.0.0.1 --port 5000 --reload"
 
 [dependencies]
 python = ">=3.11"


### PR DESCRIPTION
Fixes #15

## 背景

Issue 里点名了 2 处，实际全仓扫下来，**host 级监听共 15 处默认 `0.0.0.0`**，覆盖网关 + 全部 7 个下游模块。在当前「无认证 + pipeline 接口可指定任意可执行路径」（#16 / #17）的前提下，只要在工位或分析服务器上 `pixi run`，整套服务就对局域网可达 —— 这正是 issue 说的「从理论变为可被直接利用」。

## 改动

统一改为**默认 `127.0.0.1`，保留显式放开的开关**：

| 位置 | 环境变量 | 说明 |
|---|---|---|
| `gateway` | `OPENRARE_HOST` / `OPENRARE_PORT` | 原为硬编码 `0.0.0.0:8000`；启动横幅也改为打印真实绑定地址（原来恒打印 `0.0.0.0:8000`，即使换了地址也不变） |
| `RareSystem backend` | `API_HOST` | **顺带修了一个不一致**：`run.py` 读 `API_HOST`，但 `main.py` 直接忽略它硬编码 `0.0.0.0` —— 直接跑 `main.py` 时环境变量是失效的 |
| `pipeline` / `ppi_score` | `FULL_PIPELINE_API_HOST` / `RARE_PPI_HOST` | 保持模块级变量优先，回落到 `OPENRARE_HOST`，再回落 `127.0.0.1` |
| `rare_sort` / `report` / `phenotype_score` / `RAG-HPO` | `OPENRARE_HOST` | pixi task 与 `__main__` 入口 |
| `RareSystem` vite dev server | — | 它把 `/api` 代理到后端，对外开就等于把后端一起开出去 |

## 两个刻意没改的地方

1. **容器内的 `0.0.0.0` 全部保留**（`Dockerfile`、`Dockerfile.dev`、`docker-compose.yml`、`supervisord.conf`、`docker/start.sh`）。容器里绑回环反而是错的 —— 隔离边界是容器本身，且 `docker run -p` 无法把端口映射到容器 loopback 上的进程，改了会直接让镜像不可用。已在 `docker/start.sh` 加注释说明两侧为何不同。
2. **根目录 `pixi_rare_sort_fastapi/` 的重复副本**：与 `modules/` 下那份逐字节相同，本 PR 两份一起改，避免继续漂移。副本本身的删除留给 #19。

## 验证

- 全部改动文件通过 `py_compile` / `bash -n` / `tomllib` 解析。
- 嵌套默认值展开 `${A:-${B:-127.0.0.1}}` 四种组合实测：都不设→`127.0.0.1`；只设 `OPENRARE_HOST`→跟随；只设模块级→跟随；两者都设→模块级优先。
- socket 层实测确认语义：绑 `127.0.0.1` 时从本机局域网地址（`10.10.114.178`）连接被拒，绑 `0.0.0.0` 时可达。
- 网关代理目标本来就是 `http://127.0.0.1:<port>`，模块改绑回环后网关仍可访问；只有跨机访问受影响。

## 一个顺带发现（本 PR 未处理）

网关注册表里 `pipeline` 期望 8002、`phenotype_score` 期望 8003，但这两个模块是以 `task` 方式拉起的，用的是模块自己的默认端口 18901 / 7773，网关并未注入端口环境变量 —— 这两个模块在网关下应该一直是 health 失败状态。与 #15 无关，需要的话我另开 issue。
