### PR TITLE
security: pipeline API 路径沙箱化 (Fixes #17)

### DIFF
--- a/modules/pipeline/complete_pipeline/full_pipeline_api.py
+++ b/modules/pipeline/complete_pipeline/full_pipeline_api.py
@@ -40,6 +40,92 @@ DEFAULT_PSEUDOGENE_SCRIPT = ROOT / "modules" / "pseudogene_annotation" / "script
 DEFAULT_JAVA_BIN = os.getenv("JAVA_BIN", "java")
 
 JOBS_DIR.mkdir(parents=True, exist_ok=True)
+
+# ── Path sandbox ──────────────────────────────────────────────────────
+# Request bodies used to carry raw filesystem paths straight into the
+# pipeline command, which meant any caller could read files outside the
+# data directories, write outputs anywhere the service user can write,
+# and (via output_dir + the job-file download routes) turn this API into
+# an arbitrary file reader. Paths from a request are now confined to an
+# explicit set of roots.
+#
+# Read roots default to the directories the deployment already points at
+# through path_utils, so a correctly configured install keeps working.
+# Extra roots can be added with FULL_PIPELINE_API_ALLOWED_ROOTS
+# (comma-separated). Outputs are confined to FULL_PIPELINE_API_OUTPUT_ROOT
+# (default: the jobs directory).
+
+
+def resolve_path(value: str | Path) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    # resolve() also collapses '..' and follows symlinks, so a link
+    # planted inside an allowed root cannot point back out of it.
+    return path.resolve()
+
+
+# Normalise the jobs directory once: FULL_PIPELINE_API_JOBS_DIR may be
+# relative or contain symlinks, and every containment check below compares
+# against resolved paths.
+JOBS_DIR = resolve_path(JOBS_DIR)
+
+
+def _split_env_paths(raw: str) -> list[Path]:
+    return [resolve_path(part) for part in raw.split(",") if part.strip()]
+
+
+def _default_read_roots() -> list[Path]:
+    roots = [
+        ROOT,
+        JOBS_DIR,
+        DEFAULT_REF_DIR,
+        DEFAULT_BEAGLE_JAR.parent,
+        DEFAULT_GENOS_EVEE_DB.parent,
+        DEFAULT_CCRE_BED.parent,
+        DEFAULT_NCRNA_BED.parent,
+    ]
+    for var in ("OPENRARE_DATA_ROOT", "OPENRARE_PUBLIC_DATA_ROOT"):
+        configured = os.getenv(var)
+        if configured:
+            roots.append(resolve_path(configured))
+    return roots
+
+
+ALLOWED_READ_ROOTS = _default_read_roots() + _split_env_paths(
+    os.getenv("FULL_PIPELINE_API_ALLOWED_ROOTS", "")
+)
+OUTPUT_ROOT = resolve_path(os.getenv("FULL_PIPELINE_API_OUTPUT_ROOT", str(JOBS_DIR)))
+
+# job_id is always uuid4().hex; validating it keeps a crafted id from
+# walking out of JOBS_DIR via the /jobs/{job_id} routes.
+_JOB_ID_RE = re.compile(r"\A[0-9a-f]{32}\Z")
+
+
+def _is_within(candidate: Path, root: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def sandboxed_path(value: str | Path, field: str, roots: list[Path]) -> Path:
+    path = resolve_path(value)
+    if not any(_is_within(path, root) for root in roots):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field}: path is outside the allowed data roots",
+        )
+    return path
+
+
+def validate_job_id(job_id: str) -> str:
+    if not _JOB_ID_RE.match(job_id):
+        raise HTTPException(status_code=404, detail="job_id not found")
+    return job_id
+
+
 _LOCK = threading.Lock()
 _QUEUE_CONDITION = threading.Condition()
 _PENDING_JOBS: deque[dict] = deque()
@@ -72,14 +158,12 @@ class RunRequest(BaseModel):
         None,
         description="Advanced override: chromosomes processed by Beagle. Default auto phases every patient contig with a reference panel; X/Y/MT and other unsupported contigs are preserved for VEP",
     )
-    ref_dir: Optional[str] = Field(None, description="Advanced override: CHN reference panel directory")
-    beagle_jar: Optional[str] = Field(None, description="Advanced override: Beagle jar path")
+    ref_dir: Optional[str] = Field(None, description="Advanced override: CHN reference panel directory (must be inside an allowed data root)")
     ccre_bed: Optional[str] = Field(None, description="Advanced override: cCRE BED.GZ")
     ncrna_bed: Optional[str] = Field(None, description="Advanced override: ncRNA BED.GZ")
     chr_jobs: Optional[int] = Field(None, description="Advanced override: concurrent chromosomes for phasing")
     beagle_threads: Optional[int] = Field(None, description="Advanced override: threads per Beagle process")
     java_heap_gb: Optional[int] = Field(None, description="Advanced override: Java heap per Beagle process")
-    java_bin: Optional[str] = Field(None, description="Advanced override: Java executable for Beagle")
     top_k_transcripts: Optional[int] = Field(None, description="Advanced override: transcript selection count")
     clinical_tissue: str = Field("", description="Advanced override: GTEx tissue name for phenotype-aware transcript expression")
     genos_evee_db: Optional[str] = Field(None, description="Advanced override: indexed GENOS-VarRisk CPRA TSV.GZ")
@@ -100,15 +184,8 @@ def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def resolve_path(value: str | Path) -> Path:
-    path = Path(value).expanduser()
-    if not path.is_absolute():
-        path = Path.cwd() / path
-    return path.resolve()
-
-
 def status_path(job_id: str) -> Path:
-    return JOBS_DIR / job_id / "status.json"
+    return JOBS_DIR / validate_job_id(job_id) / "status.json"
 
 
 def read_status(job_id: str) -> dict:
@@ -268,7 +345,7 @@ def save_upload(upload: UploadFile, upload_dir: Path) -> Path:
 
 
 def build_command(req: RunRequest, output_dir: Path) -> list[str]:
-    input_vcf = resolve_path(req.input_vcf)
+    input_vcf = sandboxed_path(req.input_vcf, "input_vcf", ALLOWED_READ_ROOTS)
     cmd = [
         "bash",
         str(RUN_SCRIPT),
@@ -296,17 +373,23 @@ def build_command(req: RunRequest, output_dir: Path) -> list[str]:
     add_option("--input-assembly", req.input_assembly)
     add_option("--sample-id", req.sample_id)
     add_option("--chromosomes", req.chromosomes)
-    add_option("--ref-dir", resolve_path(req.ref_dir) if req.ref_dir else None)
-    add_option("--beagle-jar", resolve_path(req.beagle_jar) if req.beagle_jar else None)
-    add_option("--ccre-bed", resolve_path(req.ccre_bed) if req.ccre_bed else None)
-    add_option("--ncrna-bed", resolve_path(req.ncrna_bed) if req.ncrna_bed else None)
+    def add_path_option(name: str, field: str, value: Optional[str]) -> None:
+        if not value:
+            return
+        add_option(name, sandboxed_path(value, field, ALLOWED_READ_ROOTS))
+
+    add_path_option("--ref-dir", "ref_dir", req.ref_dir)
+    add_path_option("--ccre-bed", "ccre_bed", req.ccre_bed)
+    add_path_option("--ncrna-bed", "ncrna_bed", req.ncrna_bed)
     add_option("--chr-jobs", req.chr_jobs)
     add_option("--beagle-threads", req.beagle_threads)
     add_option("--java-heap-gb", req.java_heap_gb)
-    add_option("--java-bin", resolve_path(req.java_bin) if req.java_bin else None)
+    # --java-bin and --beagle-jar are deliberately not settable per request:
+    # both name an executable the pipeline then runs. They stay server-side
+    # configuration (JAVA_BIN / FULL_PIPELINE_BEAGLE_JAR).
     add_option("--top-k-transcripts", req.top_k_transcripts)
     add_option("--clinical-tissue", req.clinical_tissue)
-    add_option("--GENOS-VarRisk-db", resolve_path(req.genos_evee_db) if req.genos_evee_db else None)
+    add_path_option("--GENOS-VarRisk-db", "genos_evee_db", req.genos_evee_db)
     if req.keep_raw_vep is not None:
         cmd.extend(["--keep-raw-vep", "yes" if req.keep_raw_vep else "no"])
     if req.dry_run:
@@ -423,7 +506,11 @@ def enqueue_run(
         raise HTTPException(status_code=500, detail=f"run script not found: {RUN_SCRIPT}")
     job_id = job_id or uuid.uuid4().hex
     job_dir = JOBS_DIR / job_id
-    output_dir = resolve_path(req.output_dir) if req.output_dir else job_dir / "output"
+    output_dir = (
+        sandboxed_path(req.output_dir, "output_dir", [OUTPUT_ROOT])
+        if req.output_dir
+        else job_dir / "output"
+    )
     job_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
     cmd = build_command(req, output_dir)
@@ -471,13 +558,11 @@ def submit_upload(
     sample_id: Optional[str] = Form(None),
     chromosomes: Optional[str] = Form(None),
     ref_dir: Optional[str] = Form(None),
-    beagle_jar: Optional[str] = Form(None),
     ccre_bed: Optional[str] = Form(None),
     ncrna_bed: Optional[str] = Form(None),
     chr_jobs: Optional[int] = Form(None),
     beagle_threads: Optional[int] = Form(None),
     java_heap_gb: Optional[int] = Form(None),
-    java_bin: Optional[str] = Form(None),
     top_k_transcripts: Optional[int] = Form(None),
     clinical_tissue: str = Form(""),
     genos_evee_db: Optional[str] = Form(None),
@@ -506,13 +591,11 @@ def submit_upload(
         sample_id=sample_id,
         chromosomes=chromosomes,
         ref_dir=ref_dir,
-        beagle_jar=beagle_jar,
         ccre_bed=ccre_bed,
         ncrna_bed=ncrna_bed,
         chr_jobs=chr_jobs,
         beagle_threads=beagle_threads,
         java_heap_gb=java_heap_gb,
-        java_bin=java_bin,
         top_k_transcripts=top_k_transcripts,
         clinical_tissue=clinical_tissue,
         genos_evee_db=genos_evee_db,
@@ -552,6 +635,11 @@ def output_root_for_job(job_id: str) -> Path:
     if not output_dir:
         raise HTTPException(status_code=404, detail="job output directory is not available")
     root = Path(output_dir).expanduser().resolve()
+    # Defence in depth: status.json is written by this service, but if an
+    # older job (recorded before output_dir was sandboxed) names a path
+    # outside the output root, do not serve files from it.
+    if not _is_within(root, OUTPUT_ROOT):
+        raise HTTPException(status_code=403, detail="job output directory is outside the output root")
     if not root.is_dir():
         raise HTTPException(status_code=404, detail="job output directory does not exist yet")
     return root
@@ -634,7 +722,9 @@ def download_job_file(job_id: str, file_path: str) -> FileResponse:
 @app.get("/jobs/{job_id}/log")
 def get_job_log(job_id: str) -> str:
     status = read_status(job_id)
-    log_path = Path(status.get("log", JOBS_DIR / job_id / "api_run.log"))
+    log_path = Path(status.get("log", JOBS_DIR / job_id / "api_run.log")).expanduser().resolve()
+    if not _is_within(log_path, JOBS_DIR):
+        raise HTTPException(status_code=403, detail="log path is outside the jobs directory")
     if not log_path.is_file():
         raise HTTPException(status_code=404, detail="log not found")
     return log_path.read_text(encoding="utf-8", errors="replace")
@@ -643,7 +733,9 @@ def get_job_log(job_id: str) -> str:
 @app.get("/jobs/{job_id}/api-log/download", name="download_api_log")
 def download_api_log(job_id: str) -> FileResponse:
     status = read_status(job_id)
-    log_path = Path(status.get("log", JOBS_DIR / job_id / "api_run.log"))
+    log_path = Path(status.get("log", JOBS_DIR / job_id / "api_run.log")).expanduser().resolve()
+    if not _is_within(log_path, JOBS_DIR):
+        raise HTTPException(status_code=403, detail="log path is outside the jobs directory")
     if not log_path.is_file():
         raise HTTPException(status_code=404, detail="log not found")
     return FileResponse(log_path, filename=f"{job_id}.api_run.log")

--- a/modules/pipeline/pixi.toml
+++ b/modules/pipeline/pixi.toml
@@ -44,6 +44,7 @@ api = { cmd = [
 api-test = { cmd = ["bash", "test/run_api_integration_test.sh"] }
 mock-smoke-test = { cmd = ["bash", "test/run_mock_smoke_dryrun.sh"] }
 hla-filter-test = { cmd = ["bash", "test/run_hla_filter_unit.sh"] }
+path-sandbox-test = { cmd = ["python", "test/test_path_sandbox.py"] }
 xy-mt-preservation-test = { cmd = ["bash", "test/run_xy_mt_preservation_test.sh"] }
 vep-setup-plugins = { cmd = ["bash", "modules/vep_runner/scripts/install_vep_plugins.sh"] }
 vep-verify-plugins = { cmd = ["bash", "modules/vep_runner/scripts/verify_vep_plugins.sh"] }

--- a/modules/pipeline/test/test_path_sandbox.py
+++ b/modules/pipeline/test/test_path_sandbox.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Path-sandbox regression tests for the full pipeline API (issue #17).
+
+Run standalone (no pytest needed):
+
+    python test/test_path_sandbox.py
+
+Each case drives the real FastAPI app through TestClient and asserts that a
+request path escaping the configured roots is rejected, while the equivalent
+in-sandbox request is still accepted.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+PIPELINE_ROOT = Path(__file__).resolve().parents[1]
+
+# Point the sandbox at a scratch tree before importing the app, so the test
+# never touches a real deployment's data directories.
+_TMP = tempfile.mkdtemp(prefix="openrare_sandbox_test_")
+DATA_ROOT = Path(_TMP) / "data"
+JOBS_DIR = Path(_TMP) / "jobs"
+OUTSIDE = Path(_TMP) / "outside"
+for d in (DATA_ROOT, JOBS_DIR, OUTSIDE):
+    d.mkdir(parents=True, exist_ok=True)
+# resolve() after mkdir so comparisons match the app's resolved paths
+# (on Windows tempfile hands back an 8.3 short path).
+DATA_ROOT, JOBS_DIR, OUTSIDE = (d.resolve() for d in (DATA_ROOT, JOBS_DIR, OUTSIDE))
+
+os.environ["FULL_PIPELINE_API_JOBS_DIR"] = str(JOBS_DIR)
+os.environ["FULL_PIPELINE_API_OUTPUT_ROOT"] = str(JOBS_DIR)
+os.environ["FULL_PIPELINE_API_ALLOWED_ROOTS"] = str(DATA_ROOT)
+
+sys.path.insert(0, str(PIPELINE_ROOT))
+from fastapi.testclient import TestClient  # noqa: E402
+
+from complete_pipeline import full_pipeline_api as api  # noqa: E402
+
+SECRET = OUTSIDE / "secret.txt"
+SECRET.write_text("patient genome, not yours\n", encoding="utf-8")
+IN_SANDBOX_VCF = DATA_ROOT / "sample.vcf"
+IN_SANDBOX_VCF.write_text("##fileformat=VCFv4.2\n", encoding="utf-8")
+
+client = TestClient(api.app)
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        print(f"  FAIL  {name} {detail}")
+        FAILURES.append(name)
+
+
+def base_body(**overrides) -> dict:
+    body = {"input_vcf": str(IN_SANDBOX_VCF), "dry_run": True}
+    body.update(overrides)
+    return body
+
+
+print("\n[1] input_vcf outside the allowed roots is rejected")
+r = client.post("/run", json=base_body(input_vcf=str(SECRET)))
+check("absolute path outside roots -> 400", r.status_code == 400, r.text[:200])
+
+r = client.post("/run", json=base_body(input_vcf=f"{DATA_ROOT}/../outside/secret.txt"))
+check("'..' traversal out of an allowed root -> 400", r.status_code == 400, r.text[:200])
+
+print("\n[2] output_dir cannot escape the output root")
+r = client.post("/run", json=base_body(output_dir=str(OUTSIDE / "pwned")))
+check("output_dir outside output root -> 400", r.status_code == 400, r.text[:200])
+check(
+    "no directory was created outside the root",
+    not (OUTSIDE / "pwned").exists(),
+)
+
+print("\n[3] executable paths are no longer request fields")
+fields = set(api.RunRequest.model_fields)
+check("java_bin removed from RunRequest", "java_bin" not in fields)
+check("beagle_jar removed from RunRequest", "beagle_jar" not in fields)
+r = client.post("/run", json=base_body(java_bin="/tmp/evil.sh", beagle_jar="/tmp/evil.jar"))
+# Extra keys are ignored by the model; what matters is that neither reaches the command.
+if r.status_code in (200, 202):
+    job = r.json()["job_id"]
+    cmd = " ".join(api.read_status(job)["command"])
+    check("--java-bin absent from built command", "--java-bin" not in cmd, cmd)
+    check("--beagle-jar absent from built command", "--beagle-jar" not in cmd, cmd)
+    check("evil.sh never appears in the command", "evil.sh" not in cmd, cmd)
+else:
+    check("submitting the removed fields is at least not accepted", r.status_code == 400, r.text[:200])
+
+print("\n[4] other data-path overrides are sandboxed too")
+for field in ("ref_dir", "ccre_bed", "ncrna_bed", "genos_evee_db"):
+    r = client.post("/run", json=base_body(**{field: str(OUTSIDE)}))
+    check(f"{field} outside roots -> 400", r.status_code == 400, r.text[:200])
+
+print("\n[5] job_id cannot walk out of the jobs directory")
+for bad in ("../../etc", "..", "not-a-uuid", "0" * 31, "g" * 32):
+    r = client.get(f"/jobs/{bad}")
+    check(f"job_id={bad!r} -> 404", r.status_code == 404, r.text[:120])
+
+print("\n[6] a legitimate in-sandbox request still works")
+r = client.post("/run", json=base_body())
+check("in-sandbox submit accepted", r.status_code in (200, 202), r.text[:200])
+if r.status_code in (200, 202):
+    payload = r.json()
+    out = Path(payload["output_dir"]).resolve()
+    check("default output_dir lands under the jobs dir", api._is_within(out, JOBS_DIR), str(out))
+    r2 = client.post("/run", json=base_body(output_dir=str(JOBS_DIR / "custom_out")))
+    check("explicit output_dir inside the root accepted", r2.status_code in (200, 202), r2.text[:200])
+
+print("\n[7] file download cannot be aimed outside the output root")
+status_file = JOBS_DIR / ("f" * 32) / "status.json"
+status_file.parent.mkdir(parents=True, exist_ok=True)
+status_file.write_text(f'{{"status": "succeeded", "output_dir": "{OUTSIDE.as_posix()}"}}', encoding="utf-8")
+r = client.get(f"/jobs/{'f' * 32}/files")
+check("legacy job pointing outside the root -> 403", r.status_code == 403, r.text[:200])
+r = client.get(f"/jobs/{'f' * 32}/files/secret.txt")
+check("downloading through such a job -> 403", r.status_code == 403, r.text[:200])
+check("secret contents never returned", "not yours" not in r.text)
+
+print()
+if FAILURES:
+    print(f"{len(FAILURES)} check(s) FAILED: {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all path-sandbox checks passed")


### PR DESCRIPTION
Fixes #17

## 先说复现

Issue 里判断「不存在 shell 注入，但可指定任意可执行文件 + 任意路径」是准的。实际验证下来，**还有一条 issue 没点到的链路，危害更直接**：

`output_dir` 由调用方指定且未经校验，而 `/jobs/{job_id}/files` 和 `/jobs/{job_id}/files/{path}` 是相对 `status.json` 里记录的 `output_dir` 提供文件的。`safe_job_file()` 确实做了 `relative_to(root)` 防穿越 —— **但那个 root 本身就是攻击者给的**。于是：

```
POST /run  {"input_vcf": "...", "output_dir": "<任意目录>", "dry_run": true}
GET  /jobs/<id>/files              → 列出该目录
GET  /jobs/<id>/files/secret.txt   → 拿到文件内容
```

在修复前的代码上实测：三步分别返回 `202` / `200`（列出了目录内容）/ `200` + 文件明文。**`dry_run: true` 即可，完全不需要真的跑 pipeline。**

同一次验证还确认了：`--java-bin /tmp/evil.sh` 确实进入了最终命令行；任意深度目录会被 `mkdir(parents=True)` 创建出来。

## 改法

1. **路径沙箱**。读路径必须落在部署本来就配置好的根目录内（仓库根、jobs 目录、ref/beagle/GENOS/cCRE/ncRNA 数据目录、`OPENRARE_DATA_ROOT`、`OPENRARE_PUBLIC_DATA_ROOT`），额外根用 `FULL_PIPELINE_API_ALLOWED_ROOTS` 追加。写路径必须落在 `FULL_PIPELINE_API_OUTPUT_ROOT`（默认 jobs 目录）内。全程走 `resolve()`，所以 `..` 和符号链接都逃不出去。

   > 之所以默认根取自 `path_utils`，是为了让**配置正确的现有部署零改动**继续跑。

2. **`java_bin` / `beagle_jar` 从请求模型和 multipart 表单里删掉**，改为纯服务端配置（`JAVA_BIN` / `FULL_PIPELINE_BEAGLE_JAR`）—— 按 issue 的方案 2。注意：原先不传这两个字段时走的就是脚本默认值，所以**对任何非恶意调用方行为不变**。

3. **`job_id` 格式校验**（uuid4 hex）。这是顺带发现的：`status_path()` 直接拼 `JOBS_DIR / job_id`，构造 `job_id` 可以走出 jobs 目录。

4. **读取侧复检**：`output_root_for_job()` 和日志接口再确认一次路径在根内 —— 这样**本次改动之前已经落库的恶意 job 也不会继续可用**（返回 403），不需要清库。

5. `JOBS_DIR` 在 import 时 `resolve()` 一次。原先它直接取环境变量，相对路径或软链会让后续所有包含判断失准。

## 测试

新增 `test/test_path_sandbox.py`，**22 项检查全绿**，注册为 `pixi run path-sandbox-test`。不依赖 pytest（仓库目前没有 pytest 基建，见 #19），直接 `python test/test_path_sandbox.py` 即可跑。

覆盖：上面每一条逃逸路径 + 「合法请求必须仍然成功」的反向用例（默认 output_dir、显式指定根内 output_dir、根内 input_vcf）。

补充一个测试里踩到的点：`tempfile.mkdtemp()` 在 Windows 返回 8.3 短路径，与 `resolve()` 后的路径不相等 —— 这也正是我把 `JOBS_DIR` 改成启动时 resolve 的原因，否则真实部署里若 jobs 目录含软链，包含判断会静默失效。

## 说明

本 PR 从 `dev` 切出，不含 #29（Fixes #15）的改动，两个可独立审阅、独立合并。

`#16`（无认证 / IDOR）我认为是这三个安全 issue 里唯一真正的架构决策，我会在 issue 下写方案而不是直接提 PR —— 沙箱化只是把「任何人可读任意文件」收敛成「任何人可读数据目录内的文件」，**在认证落地之前，暴露面依然存在**。
