### PR TITLE
ci: 新增合并门禁（TOML / shell / Python 语法 + 前端类型检查）(#19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+# Merge gates for OpenRare (issue #19).
+#
+# Scope note: the analysis modules need external reference data measured in
+# hundreds of GB (VEP caches, GTEx, reference panels), so the real pipeline
+# cannot run here. These jobs deliberately cover only what is checkable
+# without that data and what is green on `dev` today, so a red check always
+# means "this PR broke something" rather than "CI is broken again".
+#
+# Checks that are NOT gates yet, and why, are tracked in issue #19.
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hygiene:
+    name: Repo hygiene (TOML / shell / Python syntax)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Every TOML parses
+        # A malformed pixi.toml breaks `pixi install` for the whole module,
+        # and it is easy to land because nothing here imports it.
+        run: |
+          python - <<'PY'
+          import sys, tomllib
+          from pathlib import Path
+          bad = []
+          files = [p for p in Path('.').rglob('*.toml')
+                   if not any(part in ('.git', '.pixi', 'node_modules') for part in p.parts)]
+          for p in files:
+              try:
+                  tomllib.loads(p.read_text(encoding='utf-8'))
+              except Exception as exc:
+                  bad.append(f'{p}: {exc}')
+          print(f'checked {len(files)} TOML files')
+          if bad:
+              print('\n'.join(bad), file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Every shell script parses
+        # Module entrypoints are shell scripts; a syntax error only shows up
+        # when someone tries to start that service.
+        run: |
+          set -euo pipefail
+          fail=0
+          count=0
+          while IFS= read -r -d '' f; do
+            count=$((count + 1))
+            bash -n "$f" || { echo "::error file=$f::bash syntax error"; fail=1; }
+          done < <(find . -name '*.sh' -not -path './.git/*' -not -path '*/node_modules/*' -print0)
+          echo "checked $count shell scripts"
+          exit $fail
+
+      - name: Python sources compile
+        # Syntax-only. Catches a broken merge or a stray conflict marker in
+        # any module, without needing that module's dependencies installed.
+        run: |
+          python -m compileall -q \
+            -x '(\.pixi|node_modules|\.git|__pycache__)' \
+            .
+
+  frontend:
+    name: RareSystem frontend (typecheck)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: modules/RareSystem/frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: modules/RareSystem/frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Typecheck
+        # `tsc -b` is green on dev, so it can gate. `npm run lint` and
+        # `npx vitest run` are NOT wired up yet -- both are currently red on
+        # dev; see issue #19 for the breakdown.
+        run: npx tsc -b

--- a/modules/RareSystem/frontend/src/__tests__/BrowseCases.test.tsx
+++ b/modules/RareSystem/frontend/src/__tests__/BrowseCases.test.tsx
@@ -17,6 +17,23 @@ vi.mock('../services/api', () => ({
 
 import api from '../services/api'
 
+// vi.mock is hoisted above every other statement in this file, so anything it
+// references must be hoisted too -- a plain `const` declared next to the mock
+// (or worse, inside a test body) is still in the temporal dead zone when the
+// factory runs, and the whole module fails to load.
+const { mockMessageError } = vi.hoisted(() => ({ mockMessageError: vi.fn() }))
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd')
+  return {
+    ...actual,
+    message: {
+      ...actual.message,
+      error: mockMessageError,
+    },
+  }
+})
+
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
@@ -326,19 +343,6 @@ describe('BrowseCases Delete Functionality', () => {
       ;(api.deleteCase as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error('Failed to delete case')
       )
-
-      // Mock message.error
-      const mockMessageError = vi.fn()
-      vi.mock('antd', async () => {
-        const actual = await vi.importActual('antd')
-        return {
-          ...actual,
-          message: {
-            ...actual.message,
-            error: mockMessageError,
-          },
-        }
-      })
 
       renderWithRouter(
         <BrowseCases 

--- a/modules/RareSystem/frontend/src/components/__tests__/Settings.test.tsx
+++ b/modules/RareSystem/frontend/src/components/__tests__/Settings.test.tsx
@@ -23,7 +23,9 @@ describe('Settings Component', () => {
     render(<Settings />)
     
     await waitFor(() => {
-      expect(screen.getByText('LLM Settings')).toBeInTheDocument()
+      // "LLM Settings" appears twice: as the tab label and as the card
+      // heading. Query the heading so the assertion stays unambiguous.
+      expect(screen.getByRole('heading', { name: 'LLM Settings' })).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
对应 #19 的第 1 点。**第 3 点（删除根目录重复副本）我查完之后认为不能删，原因见文末——这是本 PR 最重要的发现。**

## 加了什么

`.github/workflows/ci.yml`，两个 job，**只收在 `dev` 上已经是绿的检查**：

| Job | 检查 | 为什么值得当门禁 |
|---|---|---|
| `hygiene` | 所有 TOML 可解析 | 一个写坏的 `pixi.toml` 会让整个模块 `pixi install` 失败，而且没有任何代码 import 它，很容易混进来 |
| | 所有 `.sh` 过 `bash -n` | 模块入口全是 shell 脚本，语法错要等到有人启动那个服务才暴露 |
| | 所有 Python 可编译 | 只查语法，因此**不需要装任何模块依赖**，整个 job 约 1 分钟 |
| `frontend` | `npm ci` + `tsc -b` | 前端唯一在 dev 上是绿的检查 |

### 门禁是验证过会变红的

我在 astron-agent 那边踩过「CI 静默失效变假绿」的坑，所以这次每一步都做了双向验证：

- **干净仓库**：三步全绿（TOML 14 个、shell 34 个、compileall 全过）
- **注入故障**：分别塞入一个坏的 `.toml` / `.sh` / `.py`，三步**各自返回退出码 1 并指名出错文件**
- **清理后复跑**：恢复绿

另外 `bash -n` 那步用的是 `while ... done < <(find ...)` 进程替换而非管道——管道会把循环放进子 shell，`fail` 变量的修改传不回来，门禁就静默失效了。

## 刻意没有纳入门禁的三项

**因为它们在 `dev` 上本来就是红的，而一个一上来就红的门禁只会教会大家忽略它。**

1. **`npm run lint`** — 36 个 eslint error（主要是 `@typescript-eslint/no-explicit-any`，外加一个 `no-empty`）。
2. **`npx vitest run`** — 见下。
3. **各模块 pytest** — 需要 bioconda 依赖（`pysam` 等），得为每个模块起独立 pixi 环境。值得做，但应当单独一个 PR。

> 顺带更正 #19 的一处描述：issue 说「缺少对 ACMG 规则与变异排序的自动化回归保障」。实际上 `modules/RareSystem/tests/` 下**已经有 17 个 pytest 文件，其中就包括 `test_acmg_criteria.py`**。问题不是没写，是**从来没有任何 CI 跑过它们**。

## 顺手修了两个前端测试的真 bug

评估「vitest 能不能当门禁」时发现的：

1. **`BrowseCases.test.tsx` 整个文件加载失败，收集到 0 个测试。** 原因是 `vi.mock('antd')` 被写在**某个 test 函数体内部**，而工厂函数闭包引用了紧挨着它声明的 `const mockMessageError`。`vi.mock` 会被提升到模块最顶部，此时那个 const 还在暂时性死区 → `ReferenceError` → 整个模块炸掉。改为模块级 `vi.mock` + `vi.hoisted()`。
2. **`Settings.test.tsx`** 断言 `getByText('LLM Settings')`，但该文本同时出现在 Tab 标签和卡片标题上（`Settings.tsx:388` 和 `:393`），报 `Found multiple elements`。改用 heading role 查询。

**说清楚效果**：这两个修复把「一个加载不了的文件」变成「能跑完 10 个测试并给出诚实的断言失败」，**但没有让测试套件变绿**——`BrowseCases.test.tsx` 开头写明了它是 TDD red phase，针对的删除 UI 还没实现；另有 2 个 Settings 测试在 save/reset 按钮查询上间歇性失败，与本次改动无关（改动前后各跑一遍对比确认过）。

所以 vitest 暂时进不了门禁。要让它进，需要你们先决定：那批 red-phase 测试是**该实现功能**，还是**标成 `it.todo` / `describe.skip`**。这是你们的 TDD 节奏，我不擅自跳过别人的测试。

---

## ⚠️ 关于 #19 第 3 点：根目录副本**不能直接删**

issue 说「`pixi_rare_sort_fastapi/` 在根目录和 `modules/` 下各有一份副本，易不一致，建议删除根目录重复副本」。

我原本打算照做，查完发现：**两份已经不一致了，而且根目录那份包含 `modules/` 那份没有的功能。**

| | 根目录副本 | `modules/` 副本 |
|---|---|---|
| `evidence_summary` / `_evidence_str()` | ✅ 有（`pipeline.py` 里 5 处） | ❌ 完全没有 |
| `check.py` | ❌ 无 | ✅ 有（`doctor/registry.py` 依赖它） |
| `_core.py` 里 `clinvar_score` 的位置 | 第 **5** 个 | 第 **1** 个 |

被实际使用的是 `modules/` 那份（`gateway/src/gateway/main.py:77` 和 `doctor/registry.py:13` 都指向它）。**也就是说，线上跑的那份反而缺少 evidence_summary 这个功能。**

而且 contributor 的顺序差异有隐藏杀伤力：根目录的 `pipeline.py` 里 `_EV_MAP[j]` 是**按注册表下标取证据描述文案**的，它的顺序和根目录 `_core.py` 一一对应。**如果有人"统一"时把 `modules/_core.py` 覆盖过去、却保留根目录的 `pipeline.py`，证据文案会全部错位——每条变异都会被贴上错误的证据说明，而且不报任何错。** 对一个宣称"证据链可追溯"的临床系统，这是最坏的一类 bug。

所以这个 PR 一行都没动这两个目录。**请你们先定哪份是权威**，我可以按结论来做：

- 若 `modules/` 权威 → 需要确认 `evidence_summary` 是被有意废弃的，还是漏合的（若是后者，得先把它移植过去再删根目录）
- 若根目录权威 → 需要把 `check.py` 并过去，再调整 gateway 与 doctor 的路径

无论哪种，**都建议单独一个 PR 并配一组已知答案的排序回归用例**（也就是 #19 的第 2 点）——在没有回归测试兜底的情况下合并这两份代码，正是 issue 自己担心的「悄悄改变变异排序结果且难以追溯」。

## 另外两个小发现（本 PR 未处理）

- **`__pycache__/*.pyc` 被提交进了仓库**（两个 `pixi_rare_sort_fastapi/` 目录下都有），而且两边的 `.pyc` 内容还不一样。
- **`tsconfig.tsbuildinfo` / `tsconfig.node.tsbuildinfo` 也被提交了**，跑一次 `tsc -b` 就会产生 diff。我在本 PR 里已把它们还原，没有夹带。

这两个建议加进 `.gitignore` 并从索引移除，需要的话我另开 PR。
